### PR TITLE
Remove solve export for compat with DifferentialEquations

### DIFF
--- a/src/Bcube.jl
+++ b/src/Bcube.jl
@@ -225,7 +225,7 @@ export assemble_dirichlet_vector,
     apply_homogeneous_dirichlet_to_vector!
 
 include("./assembler/affine_fe_system.jl")
-export AffineFESystem, solve, solve!
+export AffineFESystem
 
 include("./algebra/gradient.jl")
 export ∇


### PR DESCRIPTION
`Roots`, `DifferentialEquations` and `Bcube` export a `solve` function; which leads to conflict(s). I have removed to `Bcube` export for `solve` to fix the `euler_naca` example. Since the purpose of `Bcube` is not to "solve" directly, I think it's ok to call `Bcube.solve`. Moreover:
* the API for AffineFESystem needs to be upgraded (note for live discussion : LinearSolve as a parameter)
* as discussed, I will clean a lot of exports in a next PR