### PR TITLE
Gradient of scalar-valued PhysicalFunction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bcube"
 uuid = "cf06320b-b7f3-4748-8003-81a6b6979792"
 authors = ["Ghislain Blanchard, Lokman Bennani and Maxime Bouyges"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 FEMQuad = "be8e8821-3f6f-54c2-987c-d2773c3a52cb"

--- a/src/algebra/gradient.jl
+++ b/src/algebra/gradient.jl
@@ -103,12 +103,9 @@ function Gradient(
     MapOver(grad_shape_functionsNA(fs, n, ctype, cnodes, ξ))
 end
 
-function Gradient(
-    cellFunction::AbstractCellFunction{<:PhysicalDomain},
-    cPoint::CellPoint{ReferenceDomain},
-)
+function Gradient(cellFunction::AbstractCellFunction{<:PhysicalDomain}, cPoint::CellPoint)
     f = get_function(cellFunction)
-    x = change_domain(cPoint, PhysicalDomain())
+    x = change_domain(cPoint, PhysicalDomain()) # transparent if already in PhysicalDomain
     return ForwardDiff.gradient(f, get_coord(x))
 end
 

--- a/src/assembler/assembler.jl
+++ b/src/assembler/assembler.jl
@@ -673,7 +673,7 @@ Compute an integral, independently from a FEM/DG framework (i.e without FESpace)
 
 Return an array (of size ncells) of the integral evaluated over each cell (or face).
 
-When integrating the constant function `x -> PhysicalFunction(x -> 1)`, the sum of this
+When integrating the constant function `PhysicalFunction(x -> 1)`, the sum of this
 result array will give you:
 * the volume of the `CellDomain` if the integration was performed over a `CellDomain`
 * the area of the `BoundaryFaceDomain` if the integration was performed over a `BoundaryFaceDomain`

--- a/src/assembler/assembler.jl
+++ b/src/assembler/assembler.jl
@@ -671,8 +671,13 @@ Base.repeat(a::SVector, ::Val{N}) where {N} = reduce(vcat, ntuple(i -> a, Val(N)
 
 Compute an integral, independently from a FEM/DG framework (i.e without FESpace)
 
-Return an array of the integral evaluated over each cell (or face). To get the sum over the whole
-domain, simply apply the `sum` function.
+Return an array (of size ncells) of the integral evaluated over each cell (or face).
+
+When integrating the constant function `x -> PhysicalFunction(1)`, the sum of this
+result array will give you:
+* the volume of the `CellDomain` if the integration was performed over a `CellDomain`
+* the area of the `BoundaryFaceDomain` if the integration was performed over a `BoundaryFaceDomain`
+* **twice** the area of the `InteriorFaceDomain` if the integration was performed over an `InteriorFaceDomain`
 """
 function compute(integration::Integration)
     measure = get_measure(integration)

--- a/src/assembler/assembler.jl
+++ b/src/assembler/assembler.jl
@@ -673,7 +673,7 @@ Compute an integral, independently from a FEM/DG framework (i.e without FESpace)
 
 Return an array (of size ncells) of the integral evaluated over each cell (or face).
 
-When integrating the constant function `x -> PhysicalFunction(1)`, the sum of this
+When integrating the constant function `x -> PhysicalFunction(x -> 1)`, the sum of this
 result array will give you:
 * the volume of the `CellDomain` if the integration was performed over a `CellDomain`
 * the area of the `BoundaryFaceDomain` if the integration was performed over a `BoundaryFaceDomain`

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -52,7 +52,7 @@
         # Physical function is [x,y] -> x so its gradient is [x,y] -> [1, 0]
         # so the integral is simply the volume of Ω
         mesh = one_cell_mesh(:quad)
-        translate!(mesh, rand(2)) # `rand` to check that the ref->phys mapping is effective
+        translate!(mesh, SA[-0.5, 1.0]) # the translation vector can be anything
         scale!(mesh, 2.0)
         dΩ = Measure(CellDomain(mesh), 1)
         @test Bcube.compute(∫(∇(PhysicalFunction(x -> x[1])) ⋅ [1, 1])dΩ)[1] == 16.0

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -57,4 +57,14 @@
         dΩ = Measure(CellDomain(mesh), 1)
         @test Bcube.compute(∫(∇(PhysicalFunction(x -> x[1])) ⋅ [1, 1])dΩ)[1] == 16.0
     end
+
+    @testset "algebra" begin
+        f = PhysicalFunction(x -> 0)
+        a = Bcube.NullOperator()
+        @test dcontract(a, a) == a
+        @test dcontract(rand(), a) == a
+        @test dcontract(a, rand()) == a
+        @test dcontract(f, a) == a
+        @test dcontract(a, f) == a
+    end
 end

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -47,5 +47,14 @@
         _g = Bcube.materialize(∇(g), cInfo)
         res = Bcube.integrate_on_ref(_g, cInfo, Quadrature(qDegree))
         @test all(isapprox.(res ./ convex_quad_area(cnodes), [1.0 2.0; 3.0 4.0]))
+
+        # Gradient of scalar PhysicalFunction
+        # Physical function is [x,y] -> x so its gradient is [x,y] -> [1, 0]
+        # so the integral is simply the volume of Ω
+        mesh = one_cell_mesh(:quad)
+        translate!(mesh, rand(2)) # `rand` to check that the ref->phys mapping is effective
+        scale!(mesh, 2.0)
+        dΩ = Measure(CellDomain(mesh), 1)
+        @test Bcube.compute(∫(∇(PhysicalFunction(x -> x[1])) ⋅ [1, 1])dΩ)[1] == 16.0
     end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -46,5 +46,19 @@
         d = [SA[1 2; 10 20], SA[3 4 5; 30 40 50], SA[6 7; 60 70]]
         @test rawcat(d) == [1, 10, 2, 20, 3, 30, 4, 40, 5, 50, 6, 60, 7, 70]
         @test isa(rawcat(d), Vector)
+
+        x = [1, 2, 3]
+        @test rawcat(x) == x
+    end
+
+    @testset "matrix_2_vector_of_SA" begin
+        a = [
+            1 2 3
+            4 5 6
+        ]
+        b = Bcube.matrix_2_vector_of_SA(a)
+        @test b[1] == SA[1, 4]
+        @test b[2] == SA[2, 5]
+        @test b[3] == SA[3, 6]
     end
 end


### PR DESCRIPTION
Here is a first answer to #16 , with an implementation of the gradient of a scalar-valued PhysicalFunction. So we can now write
```julia
using Bcube
using LinearAlgebra
mesh = one_cell_mesh(:quad)
U = TrialFESpace(FunctionSpace(:Lagrange, 1), mesh; size = 2)
V = TestFESpace(U)
f = PhysicalFunction(x -> 1.0) # scalar-valued function
dΩ = Measure(CellDomain(mesh), 1)
assemble_linear(v -> ∫(∇(f) ⋅ v)dΩ, V)
```

**however**, the present development won't work for a vector-valued `PhysicalFunction` because we shall then use `ForwardDiff.jacobian` instead of `ForwardDiff.gradient`. But to do so, we need to add a `size` attribute (or a type-parameter) to `CellFunction`. Let's do this in a second PR.

misc : I have also increased the Project version, and updated the documentation to close #17 