### PR TITLE
ctype before cnodes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bcube"
 uuid = "cf06320b-b7f3-4748-8003-81a6b6979792"
 authors = ["Ghislain Blanchard, Lokman Bennani and Maxime Bouyges"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 FEMQuad = "be8e8821-3f6f-54c2-987c-d2773c3a52cb"

--- a/docs/src/api/mapping/mapping.md
+++ b/docs/src/api/mapping/mapping.md
@@ -6,8 +6,8 @@ Modules = [Bcube]
 Pages   = ["mapping.jl"]
 ```
 
-# Reference to local
+# Reference to physical
 ```@autodocs
 Modules = [Bcube]
-Pages   = ["ref2loc.jl"]
+Pages   = ["ref2phys.jl"]
 ```

--- a/src/Bcube.jl
+++ b/src/Bcube.jl
@@ -202,17 +202,7 @@ include("./integration/measure.jl")
 export AbstractMeasure, Measure, get_domain
 
 include("./integration/integration.jl")
-export ∫,
-    integrate,
-    integrate_ref,
-    integrate_n_ref,
-    integrate_n,
-    getcache_∫,
-    InvMassMatrix,
-    sparse,
-    IntegralResult,
-    assemble,
-    result
+export ∫, getcache_∫, InvMassMatrix, sparse, IntegralResult, assemble, result
 
 include("./algebra/gradient.jl")
 export ∇

--- a/src/Bcube.jl
+++ b/src/Bcube.jl
@@ -44,8 +44,7 @@ export nnodes,
     f2n_from_c2n,
     coords,
     cell_side,
-    oriented_cell_side,
-    topology_style
+    oriented_cell_side
 
 include("./mesh/shape.jl")
 export Line,

--- a/src/Bcube.jl
+++ b/src/Bcube.jl
@@ -168,13 +168,6 @@ include("./function_space/lagrange.jl")
 include("./function_space/taylor.jl")
 
 include("./mapping/mapping.jl")
-export mapping,
-    mapping_jacobian,
-    mapping_det_jacobian,
-    mapping_inv,
-    mapping_inv_jacobian,
-    mapping_jacobian_inv,
-    mapping_face
 
 include("./mapping/ref2phys.jl")
 export normal, center, grad_shape_functions, interpolate, cell_normal, get_cell_centers

--- a/src/algebra/gradient.jl
+++ b/src/algebra/gradient.jl
@@ -106,7 +106,7 @@ TODO:
 * Specialize for a ShapeFunction to use the hardcoded version instead of ForwardDiff
 """
 function Gradient(op::AbstractLazy, cPoint::CellPoint{ReferenceDomain})
-    m = mapping_jacobian_inv(get_cellnodes(cPoint), get_celltype(cPoint), get_coord(cPoint))
+    m = mapping_jacobian_inv(get_celltype(cPoint), get_cellnodes(cPoint), get_coord(cPoint))
     f(ξ) = op(CellPoint(ξ, get_cellinfo(cPoint), ReferenceDomain()))
     valS = _size_codomain(f, get_coord(cPoint))
     return _gradient(valS, f, get_coord(cPoint), m)

--- a/src/assembler/dirichlet_condition.jl
+++ b/src/assembler/dirichlet_condition.jl
@@ -266,7 +266,7 @@ function _apply_dirichlet_on_face!(
     side = cell_side(ctype, c2n[icell], f2n[kface])
     cshape = shape(ctype)
     ξcell = coords(fs_V, cshape) # ref coordinates of the FunctionSpace in the cell
-    F = mapping(cnodes, ctype)
+    F = mapping(ctype, cnodes)
 
     # local indices of dofs lying on the face (assuming scalar FE)
     idofs_loc = idof_by_face_with_bounds(fs_V, shape(ctype))[side]

--- a/src/cellfunction/cellfunction.jl
+++ b/src/cellfunction/cellfunction.jl
@@ -480,7 +480,7 @@ Warning : `cell_normal` is a "cell" operator, not a "face" operator.
 So ξ is expected to be in the reference domain of the cell.
 """
 function _tangential_projector(cnodes, ctype, ξ)
-    ν = cell_normal(cnodes, ctype, ξ)
+    ν = cell_normal(ctype, cnodes, ξ)
     return I - (ν ⊗ ν)
 end
 
@@ -541,8 +541,8 @@ function _coplanar_rotation(
 
     # We choose to use `cell_normal` instead of `normal`,
     # but we could do the same with the latter.
-    ν_n = cell_normal(cnodes_n, ctype_n, ξ_n)
-    ν_p = cell_normal(cnodes_p, ctype_p, ξ_p)
+    ν_n = cell_normal(ctype_n, cnodes_n, ξ_n)
+    ν_p = cell_normal(ctype_p, cnodes_p, ξ_p)
 
     _cos = ν_p ⋅ ν_n
     _sin = ν_p[1] * ν_n[2] - ν_p[2] * ν_n[1] # 2D-vector cross-product
@@ -563,8 +563,8 @@ function _coplanar_rotation(
 
     # We choose to use `cell_normal` instead of `normal`,
     # but we could do the same with the latter.
-    ν_n = cell_normal(cnodes_n, ctype_n, ξ_n)
-    ν_p = cell_normal(cnodes_p, ctype_p, ξ_p)
+    ν_n = cell_normal(ctype_n, cnodes_n, ξ_n)
+    ν_p = cell_normal(ctype_p, cnodes_p, ξ_p)
 
     _cos = ν_p ⋅ ν_n
     _sin = cross(ν_p, ν_n) # this is not really a 'sinus', it is (sinus x u)

--- a/src/cellfunction/cellfunction.jl
+++ b/src/cellfunction/cellfunction.jl
@@ -400,7 +400,7 @@ function LazyOperators.materialize(
     cnodes = nodes(cInfo)
     ctype = celltype(cInfo)
 
-    return normal(cnodes, ctype, kside, ξface)
+    return normal(ctype, cnodes, kside, ξface)
 end
 
 function LazyOperators.materialize(
@@ -416,7 +416,7 @@ function LazyOperators.materialize(
     cnodes = nodes(cInfo)
     ctype = celltype(cInfo)
 
-    return normal(cnodes, ctype, kside, ξface)
+    return normal(ctype, cnodes, kside, ξface)
 end
 
 """

--- a/src/cellfunction/eval_point.jl
+++ b/src/cellfunction/eval_point.jl
@@ -105,7 +105,7 @@ get_cellnodes(p::CellPoint) = nodes(get_cellinfo(p))
 get_celltype(p::CellPoint) = celltype(get_cellinfo(p))
 
 function change_domain(p::CellPoint{ReferenceDomain}, target_domain::PhysicalDomain)
-    m(x) = mapping(nodes(p.cellinfo), celltype(p.cellinfo), x)
+    m(x) = mapping(celltype(p.cellinfo), nodes(p.cellinfo), x)
     x_phy = _apply_mapping(m, get_coord(p))
     CellPoint(x_phy, p.cellinfo, target_domain)
 end
@@ -212,7 +212,7 @@ end
 """ @ghislainb : I feel like you could write only on common function for both CellPoint and FacePoint """
 function change_domain(p::FacePoint{ReferenceDomain}, ::PhysicalDomain)
     faceInfo = get_faceinfo(p)
-    m(x) = mapping(nodes(faceInfo), facetype(faceInfo), x)
+    m(x) = mapping(facetype(faceInfo), nodes(faceInfo), x)
     x_phy = _apply_mapping(m, get_coord(p))
     FacePoint(x_phy, faceInfo, PhysicalDomain())
 end

--- a/src/cellfunction/eval_point.jl
+++ b/src/cellfunction/eval_point.jl
@@ -111,7 +111,7 @@ function change_domain(p::CellPoint{ReferenceDomain}, target_domain::PhysicalDom
 end
 
 function change_domain(p::CellPoint{PhysicalDomain}, target_domain::ReferenceDomain)
-    m(x) = mapping_inv(nodes(p.cellinfo), celltype(p.cellinfo), x)
+    m(x) = mapping_inv(celltype(p.cellinfo), nodes(p.cellinfo), x)
     x_ref = _apply_mapping(m, get_coord(p))
     CellPoint(x_ref, p.cellinfo, target_domain)
 end

--- a/src/integration/integration.jl
+++ b/src/integration/integration.jl
@@ -116,7 +116,7 @@ function integrate_ref(
     quadrature::AbstractQuadrature,
     cqStyle::AbstractComputeQuadratureStyle,
 )
-    integrate_ref(topology_style(cnodes, ctype), g_ref, cnodes, ctype, quadrature, cqStyle)
+    integrate_ref(topology_style(ctype, cnodes), g_ref, cnodes, ctype, quadrature, cqStyle)
 end
 
 """
@@ -140,7 +140,7 @@ function integrate_on_ref(
     cqStyle::AbstractComputeQuadratureStyle,
 )
     integrate_on_ref(
-        topology_style(nodes(cellinfo), celltype(cellinfo)),
+        topology_style(celltype(cellinfo), nodes(cellinfo)),
         g,
         cellinfo,
         quadrature,

--- a/src/integration/integration.jl
+++ b/src/integration/integration.jl
@@ -317,7 +317,7 @@ function integrate_ref(
     # of the mapping only once,
     # and multiply all components of `gref(x)`
     f = x -> begin
-        m = mapping_det_jacobian(cnodes, ctype, get_coord(x))
+        m = mapping_det_jacobian(ctype, cnodes, get_coord(x))
         map(gx -> m * gx, g_ref(x))
     end
     int = apply_quadrature(f, shape(ctype), quadrature, mapstyle)
@@ -335,8 +335,8 @@ function getcache_∫(ctype::AbstractEntityType, cnodes, quadrature::AbstractQua
     qnodes = get_nodes(qrule)
     qweight = get_weights(qrule)
 
-    T = typeof(mapping_det_jacobian(cnodes, ctype, qnodes[1]))
-    qmap = SVector{length(qrule), T}(mapping_det_jacobian(cnodes, ctype, ξ) for ξ in qnodes)
+    T = typeof(mapping_det_jacobian(ctype, cnodes, qnodes[1]))
+    qmap = SVector{length(qrule), T}(mapping_det_jacobian(ctype, cnodes, ξ) for ξ in qnodes)
 
     return qmap, qweight, qnodes
 end
@@ -466,7 +466,7 @@ end
 
 function _apply_volume_metric(g_and_c::T, x::T1) where {T, T1}
     g, cellinfo = g_and_c
-    m = mapping_det_jacobian(nodes(cellinfo), celltype(cellinfo), get_coord(x))
+    m = mapping_det_jacobian(celltype(cellinfo), nodes(cellinfo), get_coord(x))
     cellpoint = CellPoint(x, cellinfo, ReferenceDomain())
     m * g(cellpoint)
 end

--- a/src/integration/integration.jl
+++ b/src/integration/integration.jl
@@ -248,7 +248,7 @@ function integrate_n(
     # so it doesn't need to be mapped. However for the second argument of `g` we need to send ξ from
     # the face-reference-element to the cell-reference-element to the cell-local-element.
     return integrate_ref(
-        ξ -> g(normal(cnodes, ctype, iside, ξ), mapping(cnodes, ctype, fp(ξ))),
+        ξ -> g(normal(ctype, cnodes, iside, ξ), mapping(cnodes, ctype, fp(ξ))),
         fnodes,
         ftype,
         quadrature,
@@ -283,7 +283,7 @@ function integrate_n_ref(
     # so it doesn't need to be mapped. However for the second argument of `gref` we need to send x from
     # the face-reference-element to the cell-reference-element
     return integrate_ref(
-        ξ -> g_ref(normal(cnodes, ctype, iside, ξ), fp(ξ)),
+        ξ -> g_ref(normal(ctype, cnodes, iside, ξ), fp(ξ)),
         fnodes,
         ftype,
         quadrature,

--- a/src/integration/integration.jl
+++ b/src/integration/integration.jl
@@ -86,12 +86,12 @@ end
 Integrate function `g` expressed in local element. Depending on the cell type and the space
 dimension, a volumic or a 'surfacic' integration is performed.
 """
-function integrate(g, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
-    return integrate_ref(x -> g(mapping(ctype, cnodes, x)), cnodes, ctype, quadrature)
+function integrate(g, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
+    return integrate_ref(x -> g(mapping(ctype, cnodes, x)), ctype, cnodes, quadrature)
 end
 
 """
-    integrate_ref(g_ref, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature, [::T]) where {[T<:AbstractComputeQuadratureStyle]}
+    integrate_ref(g_ref, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature, [::T]) where {[T<:AbstractComputeQuadratureStyle]}
 
 Integrate function `g_ref` expressed in reference element. A variable substitution (involving Jacobian & Cie) is still
 applied, but the function is considered to be already mapped.
@@ -103,20 +103,20 @@ If the last argument is given, computation is optimized according to the given c
 """
 function integrate_ref(
     g_ref,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
 )
-    integrate_ref(g_ref, cnodes, ctype, quadrature, ComputeQuadratureStyle(g_ref))
+    integrate_ref(g_ref, ctype, cnodes, quadrature, ComputeQuadratureStyle(g_ref))
 end
 function integrate_ref(
     g_ref,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
     cqStyle::AbstractComputeQuadratureStyle,
 )
-    integrate_ref(topology_style(ctype, cnodes), g_ref, cnodes, ctype, quadrature, cqStyle)
+    integrate_ref(topology_style(ctype, cnodes), g_ref, ctype, cnodes, quadrature, cqStyle)
 end
 
 """
@@ -149,7 +149,7 @@ function integrate_on_ref(
 end
 
 """
-    integrate(g, iside::Int, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
+    integrate(g, iside::Int, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
 
 Integrate function `g` on the `iside`-th side of the cell defined by its nodes `cnodes` and its
 type `ctype`. Function `g(x)` is expressed in the local element.
@@ -157,8 +157,8 @@ type `ctype`. Function `g(x)` is expressed in the local element.
 function integrate(
     g,
     iside::Int,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
 )
     # Get cell shape
@@ -175,14 +175,14 @@ function integrate(
     # @ghislainb : need better solution to index with tuple
     return integrate_ref(
         x -> g(mapping(ctype, cnodes, fp(x))),
-        [cnodes[i] for i in faces2nodes(ctype)[iside]],
         ftype,
+        [cnodes[i] for i in faces2nodes(ctype)[iside]],
         quadrature,
     )
 end
 
 """
-    integrate_ref(g_ref, iside::Int, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
+    integrate_ref(g_ref, iside::Int, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
 
 Integrate function `g_ref` on the `iside`-th side of the cell defined by its nodes `cnodes` and its
 type `ctype`. Function `g_ref(x)` is expressed in the cell-reference element (not the face reference).
@@ -193,8 +193,8 @@ This function is helpfull to integrate shape functions (for instance ``\\int \\l
 function integrate_ref(
     g_ref,
     iside::Int,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
 )
     # Get cell shape
@@ -210,14 +210,14 @@ function integrate_ref(
     # the cell-ref-element
     return integrate_ref(
         x -> g_ref(fp(x)),
-        [cnodes[i] for i in faces2nodes(ctype)[iside]],
         ftype,
+        [cnodes[i] for i in faces2nodes(ctype)[iside]],
         quadrature,
     )
 end
 
 """
-    integrate_n(g, iside::Int, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
+    integrate_n(g, iside::Int, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
 
 Perform an integration over the `iside`th face of an element (defined by `cnodes` and `ctype`).
 
@@ -230,8 +230,8 @@ This method is DEPRECATED : never used, except in the unit tests...
 function integrate_n(
     g,
     iside::Int,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
 )
     # Get cell shape
@@ -249,14 +249,14 @@ function integrate_n(
     # the face-reference-element to the cell-reference-element to the cell-local-element.
     return integrate_ref(
         ξ -> g(normal(ctype, cnodes, iside, ξ), mapping(ctype, cnodes, fp(ξ))),
-        fnodes,
         ftype,
+        fnodes,
         quadrature,
     )
 end
 
 """
-    integrate_n_ref(g_ref, iside::Int, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
+    integrate_n_ref(g_ref, iside::Int, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
 
 Perform an integration over the `iside`th face of an element (defined by `cnodes` and `ctype`).
 
@@ -265,8 +265,8 @@ Here `g_ref` is expressed in the cell-reference element but `n` is the normal ve
 function integrate_n_ref(
     g_ref,
     iside::Int,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
 )
     # Get cell shape
@@ -284,14 +284,14 @@ function integrate_n_ref(
     # the face-reference-element to the cell-reference-element
     return integrate_ref(
         ξ -> g_ref(normal(ctype, cnodes, iside, ξ), fp(ξ)),
-        fnodes,
         ftype,
+        fnodes,
         quadrature,
     )
 end
 
 """
-    integrate_ref(::isVolumic, g_ref, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature, ::T) where{N, T<:AbstractComputeQuadratureStyle}
+    integrate_ref(::isVolumic, g_ref, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature, ::T) where{N, T<:AbstractComputeQuadratureStyle}
 
 Integrate function `g_ref` (expressed in reference element) on mesh element of type `ctype` defined by
 its `cnodes` at the `quadrature`.
@@ -307,8 +307,8 @@ decrease performance nor allocation.
 function integrate_ref(
     ::isVolumic,
     g_ref,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
     mapstyle::MapComputeQuadratureStyle,
 )
@@ -325,18 +325,18 @@ function integrate_ref(
 end
 
 """
-    getcache_∫(etype::AbstractEntityType, nodes, quadrature::AbstractQuadrature)
+    getcache_∫(ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
 
 Return the data cache for function `∫`
 """
-function getcache_∫(etype::AbstractEntityType, nodes, quadrature::AbstractQuadrature)
-    qrule = QuadratureRule(shape(etype), quadrature)
+function getcache_∫(ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
+    qrule = QuadratureRule(shape(ctype), quadrature)
 
     qnodes = get_nodes(qrule)
     qweight = get_weights(qrule)
 
-    T = typeof(mapping_det_jacobian(nodes, etype, qnodes[1]))
-    qmap = SVector{length(qrule), T}(mapping_det_jacobian(nodes, etype, ξ) for ξ in qnodes)
+    T = typeof(mapping_det_jacobian(cnodes, ctype, qnodes[1]))
+    qmap = SVector{length(qrule), T}(mapping_det_jacobian(cnodes, ctype, ξ) for ξ in qnodes)
 
     return qmap, qweight, qnodes
 end
@@ -377,7 +377,7 @@ end
 integrate(g, cache) = ∫v(g, cache)
 
 """
-    integrate_ref(g_ref, cnodes, ctype, quadrature::AbstractQuadrature)
+    integrate_ref(g_ref, ctype, cnodes, quadrature::AbstractQuadrature)
 
 Integration on a node in a ``\\mathbb{R}^n`` space. This trivial function is only to simplify the 'side integral' expression.
 
@@ -389,8 +389,8 @@ see, `g_ref` doesnt actually depend on `ξ`
 function integrate_ref(
     ::isNodal,
     g_ref,
-    cnodes,
     ctype,
+    cnodes,
     quadrature::AbstractQuadrature,
     ::AbstractComputeQuadratureStyle,
 )
@@ -398,7 +398,7 @@ function integrate_ref(
 end
 
 """
-    integrate_ref(::isCurvilinear, g_ref, cnodes, ctype::AbstractEntityType{1}, quadrature::AbstractQuadrature, ::T) where {T<:AbstractComputeQuadratureStyle}
+    integrate_ref(::isCurvilinear, g_ref, ctype::AbstractEntityType{1}, cnodes, quadrature::AbstractQuadrature, ::T) where {T<:AbstractComputeQuadratureStyle}
 
 Perform an integration of the function `g_ref` (expressed in local element) over a line in a ``\\matbb{R}^n`` space.
 
@@ -410,8 +410,8 @@ Computation is optimized according to the given concrete type `T<:AbstractComput
 function integrate_ref(
     ::isCurvilinear,
     g_ref,
-    cnodes,
     ctype::AbstractEntityType{1},
+    cnodes,
     quadrature::AbstractQuadrature,
     mapstyle::MapComputeQuadratureStyle,
 )
@@ -474,8 +474,8 @@ end
 function integrate_ref(
     ::isSurfacic,
     g_ref,
-    cnodes,
     ctype::AbstractEntityType,
+    cnodes,
     quadrature::AbstractQuadrature,
     mapstyle::MapComputeQuadratureStyle,
 )
@@ -495,32 +495,12 @@ function integrate_face_ref(g_ref, finfo::FaceInfo, quadrature::AbstractQuadratu
     _g_ref = ξ -> g_ref(FacePoint(ξ, finfo, ReferenceDomain()))
     return integrate_ref(
         _g_ref,
-        nodes(finfo),
         facetype(finfo),
+        nodes(finfo),
         quadrature,
         ComputeQuadratureStyle(_g_ref),
     )
 end
-
-# function integrate_face_ref(g_ref, finfo::FaceInfo{T,T}, ::Val{N}) where {N,T<:CellInfo{AbstractEntityType{1}}}
-
-# end
-
-# #---------------------------------------------------------------- (deprecated) Barycentric integrals
-# """
-#     integrate(g, iside::Int, shape::AbstractShape, order::Val{N}) where{N}
-
-# Integrate function `g` on a side of reference element of type `shape`
-# using barycentric coordinates at the `order`-th order.
-
-# g has to be expressed in terms of reference coordinates
-
-# """
-# function integrate(g, iside::Int, shape::AbstractShape, order::Val{N}) where {N}
-#     vertices = coords(shape, faces2nodes(shape))[iside]
-#     weighting = x -> x[1] * x[2]
-#     return sum(x -> x[1] * g(sum(weighting, zip(x[2], vertices))), quadrature_rule_bary(iside, shape, order))
-# end
 
 struct Integrand{N, F}
     f::F

--- a/src/integration/integration.jl
+++ b/src/integration/integration.jl
@@ -423,7 +423,7 @@ function integrate_ref(
     return apply_quadrature2(f, shape(ctype), quadrature, mapstyle)
 end
 function _apply_curvilinear_metric1((g_ref, cnodes, ctype), x)
-    m = norm(mapping_jacobian(cnodes, ctype, x))
+    m = norm(mapping_jacobian(ctype, cnodes, x))
     map(gx -> m * gx, g_ref(x)) # `map` is needed by legacy
     #m*g_ref(x) ok for new api
 end
@@ -444,7 +444,7 @@ function integrate_on_ref(
 end
 
 function _apply_curvilinear_metric((g, cellinfo), x)
-    m = norm(mapping_jacobian(nodes(cellinfo), celltype(cellinfo), get_coord(x)))
+    m = norm(mapping_jacobian(celltype(cellinfo), nodes(cellinfo), get_coord(x)))
     cellpoint = CellPoint(x, cellinfo, ReferenceDomain())
     m * g(cellpoint)
 end
@@ -480,7 +480,7 @@ function integrate_ref(
     mapstyle::MapComputeQuadratureStyle,
 )
     I = function (ξ)
-        J = mapping_jacobian(cnodes, ctype, ξ)
+        J = mapping_jacobian(ctype, cnodes, ξ)
         return norm(J[:, 1] × J[:, 2])
     end
     return apply_quadrature(ξ -> I(ξ), g_ref, shape(ctype), quadrature)

--- a/src/integration/integration.jl
+++ b/src/integration/integration.jl
@@ -81,13 +81,13 @@ function integrate(g_ref, shape::AbstractShape, quadrature::AbstractQuadrature)
 end
 
 """
-    integrate(g, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
+    integrate(g, ctype::AbstractEntityType, cnodes, quadrature::AbstractQuadrature)
 
 Integrate function `g` expressed in local element. Depending on the cell type and the space
 dimension, a volumic or a 'surfacic' integration is performed.
 """
 function integrate(g, cnodes, ctype::AbstractEntityType, quadrature::AbstractQuadrature)
-    return integrate_ref(x -> g(mapping(cnodes, ctype, x)), cnodes, ctype, quadrature)
+    return integrate_ref(x -> g(mapping(ctype, cnodes, x)), cnodes, ctype, quadrature)
 end
 
 """
@@ -174,7 +174,7 @@ function integrate(
     # we need to send x, from face-ref-element to cell-ref-element to local-element.
     # @ghislainb : need better solution to index with tuple
     return integrate_ref(
-        x -> g(mapping(cnodes, ctype, fp(x))),
+        x -> g(mapping(ctype, cnodes, fp(x))),
         [cnodes[i] for i in faces2nodes(ctype)[iside]],
         ftype,
         quadrature,
@@ -248,7 +248,7 @@ function integrate_n(
     # so it doesn't need to be mapped. However for the second argument of `g` we need to send ξ from
     # the face-reference-element to the cell-reference-element to the cell-local-element.
     return integrate_ref(
-        ξ -> g(normal(ctype, cnodes, iside, ξ), mapping(cnodes, ctype, fp(ξ))),
+        ξ -> g(normal(ctype, cnodes, iside, ξ), mapping(ctype, cnodes, fp(ξ))),
         fnodes,
         ftype,
         quadrature,

--- a/src/mapping/ref2phys.jl
+++ b/src/mapping/ref2phys.jl
@@ -28,7 +28,7 @@ function normal(::isCurvilinear, ctype::AbstractEntityType, cnodes, iside, ξ)
     # Since a Line has always only two nodes, the node is necessary the `iside`-th
     ξ_cell = coords(Line())[iside]
 
-    return normalize(mapping_jacobian(cnodes, ctype, ξ_cell) .* normal(shape(ctype), iside))
+    return normalize(mapping_jacobian(ctype, cnodes, ξ_cell) .* normal(shape(ctype), iside))
 end
 
 function normal(::isSurfacic, ctype::AbstractEntityType, cnodes, iside, ξ)
@@ -40,13 +40,13 @@ function normal(::isSurfacic, ctype::AbstractEntityType, cnodes, iside, ξ)
     fnodes = [cnodes[i] for i in faces2nodes(ctype)[iside]] # @ghislainb : need better solution to index
 
     # Get face direction vector (face Jacobian)
-    u = mapping_jacobian(fnodes, ftype, ξ)
+    u = mapping_jacobian(ftype, fnodes, ξ)
 
     # Get face parametrization function
     fp = mapping_face(cshape, iside) # mapping face-ref -> cell-ref
 
     # Compute surface jacobian
-    J = mapping_jacobian(cnodes, ctype, fp(ξ))
+    J = mapping_jacobian(ctype, cnodes, fp(ξ))
 
     # Compute vector that will help orient outward normal
     orient = mapping(ctype, cnodes, fp(ξ)) - center(ctype, cnodes)
@@ -89,7 +89,7 @@ function cell_normal(
     cnodes::AbstractArray{Node{2, T}, N},
     ξ,
 ) where {T, N}
-    Jref = mapping_jacobian(cnodes, ctype, ξ)
+    Jref = mapping_jacobian(ctype, cnodes, ξ)
     return normalize(SA[-Jref[2], Jref[1]])
 end
 
@@ -98,7 +98,7 @@ function cell_normal(
     cnodes::AbstractArray{Node{3, T}, N},
     ξ,
 ) where {T, N}
-    J = mapping_jacobian(cnodes, ctype, ξ)
+    J = mapping_jacobian(ctype, cnodes, ξ)
     return normalize(J[:, 1] × J[:, 2])
 end
 
@@ -241,7 +241,7 @@ function _grad_shape_functions_hypersurface(fs, ctype, cnodes, ξ)
     # case. As long as this portion of code is not duplicated elsewhere, I prefer to
     # keep it here.
     s = shape(ctype)
-    Jref = mapping_jacobian(cnodes, ctype, ξ)
+    Jref = mapping_jacobian(ctype, cnodes, ξ)
     ν = cell_normal(ctype, cnodes, ξ)
     J = hcat(Jref, ν)
 

--- a/src/mapping/ref2phys.jl
+++ b/src/mapping/ref2phys.jl
@@ -73,36 +73,29 @@ function normal(::isVolumic, ctype::AbstractEntityType, cnodes, iside, ξ)
 end
 
 """
-    cell_normal(cnodes::AbstractArray{Node{2,T},N}, ctype::AbstractEntityType{1}, ξ) where {T, N}
+    cell_normal(ctype::AbstractEntityType, cnodes, ξ) where {T, N}
 
-Compute the cell normal vector of an entity of topology dimension equals to 1 in a 2D space,
-i.e a curve in a 2D space. This vector is expressed in the cell-reference coordinate system.
+Compute the cell normal vector of an entity of topology dimension equals to (d-1) in a n-D space,
+for instance a curve in a 2D space. This vector is expressed in the cell-reference coordinate system.
 
 Do not confuse the cell normal vector with the cell-side (i.e face) normal vector.
 
-Method : the curve direction vector, u, is J/||J||. Then n = [-u.y, u.x].
+# Topology dimension 1
+the curve direction vector, u, is J/||J||. Then n = [-u.y, u.x].
+
 """
 function cell_normal(
-    cnodes::AbstractArray{Node{2, T}, N},
     ctype::AbstractEntityType{1},
+    cnodes::AbstractArray{Node{2, T}, N},
     ξ,
 ) where {T, N}
     Jref = mapping_jacobian(cnodes, ctype, ξ)
     return normalize(SA[-Jref[2], Jref[1]])
 end
 
-"""
-    cell_normal(cnodes::AbstractArray{Node{3,T},N}, ctype::AbstractEntityType{2}, ξ) where {T, N}
-
-Compute the cell normal vector of an entity of topology dimension equals to 2 (a surface) in a 3D space.
-This vector is expressed in the cell-reference coordinate system.
-
-Do not confuse the cell normal vector with the cell-side (i.e face) normal vector.
-
-"""
 function cell_normal(
-    cnodes::AbstractArray{Node{3, T}, N},
     ctype::AbstractEntityType{2},
+    cnodes::AbstractArray{Node{3, T}, N},
     ξ,
 ) where {T, N}
     J = mapping_jacobian(cnodes, ctype, ξ)
@@ -249,7 +242,7 @@ function _grad_shape_functions_hypersurface(fs, ctype, cnodes, ξ)
     # keep it here.
     s = shape(ctype)
     Jref = mapping_jacobian(cnodes, ctype, ξ)
-    ν = cell_normal(cnodes, ctype, ξ)
+    ν = cell_normal(ctype, cnodes, ξ)
     J = hcat(Jref, ν)
 
     # Compute shape functions gradient : we "add a dimension" to the ref gradient,

--- a/src/mapping/ref2phys.jl
+++ b/src/mapping/ref2phys.jl
@@ -49,7 +49,7 @@ function normal(::isSurfacic, ctype::AbstractEntityType, cnodes, iside, ξ)
     J = mapping_jacobian(cnodes, ctype, fp(ξ))
 
     # Compute vector that will help orient outward normal
-    orient = mapping(cnodes, ctype, fp(ξ)) - center(cnodes, ctype)
+    orient = mapping(cnodes, ctype, fp(ξ)) - center(ctype, cnodes)
 
     # Normal direction
     n = J[:, 1] × J[:, 2] × u
@@ -103,7 +103,7 @@ function cell_normal(
 end
 
 """
-    center(cnodes, ctype::AbstractEntityType)
+    center(ctype::AbstractEntityType, cnodes)
 
 Return the center of the `AbstractEntityType` by mapping the center of the corresponding `Shape`.
 
@@ -111,7 +111,7 @@ Return the center of the `AbstractEntityType` by mapping the center of the corre
 Do not use this function on a face of a cell : since the face is of dimension "n-1", the mapping
 won't be appropriate.
 """
-center(cnodes, ctype::AbstractEntityType) = mapping(cnodes, ctype, center(shape(ctype)))
+center(ctype::AbstractEntityType, cnodes) = mapping(cnodes, ctype, center(shape(ctype)))
 
 """
     grad_shape_functions(::AbstractFunctionSpace, ::Val{N}, ::AbstractEntityType, nodes, ξ) where N
@@ -267,9 +267,9 @@ function get_cell_centers(mesh::Mesh)
     c2n = connectivities_indices(mesh, :c2n)
     celltypes = cells(mesh)
     centers = map(1:ncells(mesh)) do icell
-        ct = celltypes[icell]
-        cn = get_nodes(mesh, c2n[icell])
-        center(cn, ct)
+        ctype = celltypes[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
+        center(ctype, cnodes)
     end
     return centers
 end

--- a/src/mapping/ref2phys.jl
+++ b/src/mapping/ref2phys.jl
@@ -49,7 +49,7 @@ function normal(::isSurfacic, ctype::AbstractEntityType, cnodes, iside, ξ)
     J = mapping_jacobian(cnodes, ctype, fp(ξ))
 
     # Compute vector that will help orient outward normal
-    orient = mapping(cnodes, ctype, fp(ξ)) - center(ctype, cnodes)
+    orient = mapping(ctype, cnodes, fp(ξ)) - center(ctype, cnodes)
 
     # Normal direction
     n = J[:, 1] × J[:, 2] × u
@@ -111,7 +111,7 @@ Return the center of the `AbstractEntityType` by mapping the center of the corre
 Do not use this function on a face of a cell : since the face is of dimension "n-1", the mapping
 won't be appropriate.
 """
-center(ctype::AbstractEntityType, cnodes) = mapping(cnodes, ctype, center(shape(ctype)))
+center(ctype::AbstractEntityType, cnodes) = mapping(ctype, cnodes, center(shape(ctype)))
 
 """
     grad_shape_functions(::AbstractFunctionSpace, ::Val{N}, ctype::AbstractEntityType, cnodes, ξ) where N

--- a/src/mapping/ref2phys.jl
+++ b/src/mapping/ref2phys.jl
@@ -20,7 +20,7 @@ Note that the "face" normal vector of a curve is the "direction" vector at the g
 
 """
 function normal(ctype::AbstractEntityType, cnodes, iside, ξ)
-    normal(topology_style(cnodes, ctype), ctype, cnodes, iside, ξ)
+    normal(topology_style(ctype, cnodes), ctype, cnodes, iside, ξ)
 end
 
 function normal(::isCurvilinear, ctype::AbstractEntityType, cnodes, iside, ξ)
@@ -114,7 +114,7 @@ won't be appropriate.
 center(ctype::AbstractEntityType, cnodes) = mapping(cnodes, ctype, center(shape(ctype)))
 
 """
-    grad_shape_functions(::AbstractFunctionSpace, ::Val{N}, ::AbstractEntityType, nodes, ξ) where N
+    grad_shape_functions(::AbstractFunctionSpace, ::Val{N}, ctype::AbstractEntityType, cnodes, ξ) where N
 
 Gradient, with respect to the local coordinate system, of the shape functions associated to the `FunctionSpace`.
 

--- a/src/mesh/entity.jl
+++ b/src/mesh/entity.jl
@@ -510,38 +510,40 @@ struct isSurfacic <: TopologyStyle end
 struct isVolumic <: TopologyStyle end
 
 """
-    topology_style(spaceDim::Int, topoDim::Int)
+    topology_style(::AbstractEntityType{topoDim}, ::Node{spaceDim, T}) where {topoDim, spaceDim, T}
+    topology_style(::AbstractEntityType{topoDim}, ::AbstractArray{Node{spaceDim, T}, N}) where {spaceDim, T, N, topoDim}
+)
 
 Indicate the `TopologyStyle` of an entity of topology `topoDim` living in space of dimension `spaceDim`.
 """
 @inline function topology_style(
-    ::Node{spaceDim, T},
     ::AbstractEntityType{topoDim},
-) where {spaceDim, T, topoDim}
+    ::Node{spaceDim, T},
+) where {topoDim, spaceDim, T}
     isVolumic()
 end # everything is volumic by default
 @inline function topology_style(
-    ::Node{spaceDim, T},
     ::AbstractEntityType{0},
+    ::Node{spaceDim, T},
 ) where {spaceDim, T}
     isNodal()
 end # Any "Node" is... nodal
 @inline function topology_style(
-    ::Node{spaceDim, T},
     ::AbstractEntityType{1},
+    ::Node{spaceDim, T},
 ) where {spaceDim, T}
     isCurvilinear()
 end # Any "line" is curvilinear
-@inline topology_style(::Node{2, T}, ::AbstractEntityType{2}) where {T} = isVolumic() # A surface in R^2 is "volumic"
+@inline topology_style(::AbstractEntityType{2}, ::Node{2, T}) where {T} = isVolumic() # A surface in R^2 is "volumic"
 @inline function topology_style(
-    ::Node{spaceDim, T},
     ::AbstractEntityType{2},
+    ::Node{spaceDim, T},
 ) where {spaceDim, T}
     isSurfacic()
 end # Any other surface is "surfacic"
 @inline function topology_style(
-    nodes::AbstractArray{Node{spaceDim, T}, N},
     etype::AbstractEntityType{topoDim},
+    nodes::AbstractArray{Node{spaceDim, T}, N},
 ) where {spaceDim, T, N, topoDim}
-    topology_style(nodes[1], etype)
+    topology_style(etype, nodes[1])
 end

--- a/src/writers/vtk.jl
+++ b/src/writers/vtk.jl
@@ -75,7 +75,7 @@ function write_vtk_discontinuous(
     # Create coordinates arrays
     # vtknodes = reshape([coords(n)[idim] for i in 1:ncells(mesh) for n in get_nodes(mesh,c2n[i]) for idim in 1:spaceDim],spaceDim,:)
     _coords = [
-        mapping(get_nodes(mesh, c2n[i]), celltypes[i], ξ)[idim] for i in 1:ncells(mesh)
+        mapping(celltypes[i], get_nodes(mesh, c2n[i]), ξ)[idim] for i in 1:ncells(mesh)
         for ξ in _vtk_coords_from_lagrange(shape(celltypes[i]), _degree) for
         idim in 1:spaceDim
     ]
@@ -155,7 +155,7 @@ function write_vtk_bnd_discontinuous(
         sideᵢ = cell_side(celltypes[icell], c2n[icell], f2n[iface])
         localfacedofs = idof_by_face_with_bounds(fs, shape(celltypes[icell]))[sideᵢ]
         ξ = coords(fs, shape(celltypes[icell]))[localfacedofs]
-        xdofs = map(_ξ -> mapping(get_nodes(mesh, c2n[icell]), celltypes[icell], _ξ), ξ)
+        xdofs = map(_ξ -> mapping(celltypes[icell], get_nodes(mesh, c2n[icell]), _ξ), ξ)
         ftype = entity(face_shapes(shape(celltypes[icell]), sideᵢ), Val(degree))
         ftype, rawcat(xdofs)
     end

--- a/test/dof/test_variable.jl
+++ b/test/dof/test_variable.jl
@@ -24,7 +24,7 @@ function test_setvalues!_with_function(
         ctype = cellTypes[i]
         cnodes = get_nodes(mesh, c2n[i])
         uᵢ = u[i, Val(:unstable)]
-        a = [f(mapping(ctype, cnodes, x)) for x in coords(shape(ctype))]
+        a = [f(Bcube.mapping(ctype, cnodes, x)) for x in coords(shape(ctype))]
         b = [uᵢ(ξ) for ξ in coords(shape(ctype))]
 
         @test all(isapprox.(a, b, rtol = 1000eps()))

--- a/test/dof/test_variable.jl
+++ b/test/dof/test_variable.jl
@@ -21,11 +21,11 @@ function test_setvalues!_with_function(
     c2n = connectivities_indices(mesh, :c2n)
 
     for i in 1:ncells(mesh)
-        ct = cellTypes[i]
-        cn = get_nodes(mesh, c2n[i])
+        ctype = cellTypes[i]
+        cnodes = get_nodes(mesh, c2n[i])
         uᵢ = u[i, Val(:unstable)]
-        a = [f(mapping(cn, ct, x)) for x in coords(shape(ct))]
-        b = [uᵢ(ξ) for ξ in coords(shape(ct))]
+        a = [f(mapping(ctype, cnodes, x)) for x in coords(shape(ctype))]
+        b = [uᵢ(ξ) for ξ in coords(shape(ctype))]
 
         @test all(isapprox.(a, b, rtol = 1000eps()))
     end

--- a/test/integration/test_integration.jl
+++ b/test/integration/test_integration.jl
@@ -503,7 +503,7 @@ end
             cnodes = get_nodes(m)
 
             @test isapprox_arrays(
-                Bcube.mapping_jacobian(cnodes, ctype, ξηζ),
+                Bcube.mapping_jacobian(ctype, cnodes, ξηζ),
                 s .* I3;
                 rtol = 1e-14,
             )

--- a/test/integration/test_integration.jl
+++ b/test/integration/test_integration.jl
@@ -3,11 +3,11 @@ function test_divergence2d(mesh, u, degree)
     # Connectivity
     c2n = connectivities_indices(mesh, :c2n)
     cnodes = get_nodes(mesh, c2n[1])
-    ct = cells(mesh)[1]
+    ctype = cells(mesh)[1]
 
     return sum(
-        integrate_n((n, x) -> u(x) ⋅ n, iside, cnodes, ct, Quadrature(degree)) for
-        iside in 1:nfaces(ct)
+        Bcube.integrate_n((n, x) -> u(x) ⋅ n, iside, ctype, cnodes, Quadrature(degree)) for
+        iside in 1:nfaces(ctype)
     )
 end
 
@@ -18,12 +18,12 @@ end
 
         # Connectivity
         c2n = connectivities_indices(mesh, :c2n)
-        n = get_nodes(mesh, c2n[1])
+        cnodes = get_nodes(mesh, c2n[1])
 
         # Test length of line
         @test all(
-            integrate(x -> 1.0, n, cells(mesh)[1], Quadrature(Val(degree))) ≈ 1.0 for
-            degree in 1:5
+            Bcube.integrate(x -> 1.0, cells(mesh)[1], cnodes, Quadrature(Val(degree))) ≈
+            1.0 for degree in 1:5
         )
     end
 
@@ -37,118 +37,120 @@ end
 
         # Connectivity
         c2n = connectivities_indices(mesh, :c2n)
-        n = get_nodes(mesh, c2n[1])
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
+        cnodes = get_nodes(mesh, c2n[1])
+        ctype = cells(mesh)[1]
 
         # Test area of tri
         @test all(
-            integrate(x -> 1.0, n, cells(mesh)[1], Quadrature(Val(degree))) ≈ 2.0 for
-            degree in 1:5
+            Bcube.integrate(x -> 1.0, cells(mesh)[1], cnodes, Quadrature(Val(degree))) ≈
+            2.0 for degree in 1:5
         )
 
         # Test for P1 shape functions and products of P1 shape functions
         fs = FunctionSpace(:Lagrange, 1)
-        λ = shape_functions(fs, shape(ct))
+        λ = shape_functions(fs, shape(ctype))
         degree = Val(2)
         quad = Quadrature(degree)
 
-        @test integrate_ref(ξ -> λ(ξ)[1], cnodes, ct, quad) ≈ 2.0 / 3.0
-        @test integrate_ref(ξ -> λ(ξ)[2], cnodes, ct, quad) ≈ 2.0 / 3.0
-        @test integrate_ref(ξ -> λ(ξ)[3], cnodes, ct, quad) ≈ 2.0 / 3.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[1], ctype, cnodes, quad) ≈ 2.0 / 3.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[2], ctype, cnodes, quad) ≈ 2.0 / 3.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[3], ctype, cnodes, quad) ≈ 2.0 / 3.0
 
-        @test integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[1], cnodes, ct, quad) ≈ 1.0 / 3.0
-        @test integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[2], cnodes, ct, quad) ≈ 1.0 / 3.0
-        @test integrate_ref(ξ -> λ(ξ)[3] * λ(ξ)[3], cnodes, ct, quad) ≈ 1.0 / 3.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[1], ctype, cnodes, quad) ≈ 1.0 / 3.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[2], ctype, cnodes, quad) ≈ 1.0 / 3.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[3] * λ(ξ)[3], ctype, cnodes, quad) ≈ 1.0 / 3.0
 
-        @test integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[2], cnodes, ct, quad) ≈ 1.0 / 6.0
-        @test integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[3], cnodes, ct, quad) ≈ 1.0 / 6.0
-        @test integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[3], cnodes, ct, quad) ≈ 1.0 / 6.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[2], ctype, cnodes, quad) ≈ 1.0 / 6.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[3], ctype, cnodes, quad) ≈ 1.0 / 6.0
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[3], ctype, cnodes, quad) ≈ 1.0 / 6.0
 
         # Test for P2 shape functions and some products of P2 shape functions
         fs = FunctionSpace(:Lagrange, 2)
-        λ = shape_functions(fs, shape(ct))
+        λ = shape_functions(fs, shape(ctype))
 
         _atol = 2 * eps()
         _rtol = 4 * eps()
         for degree in 2:8
             # atol fixed to 1e-10 to get a pass for degree 4
+            quad = Quadrature(degree)
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[1], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[1], ctype, cnodes, quad),
                 0.0,
                 atol = _atol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[2], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[2], ctype, cnodes, quad),
                 0.0,
                 atol = _atol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[3], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[3], ctype, cnodes, quad),
                 0.0,
                 atol = _atol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[4], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[4], ctype, cnodes, quad),
                 2.0 / 3.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[5], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[5], ctype, cnodes, quad),
                 2.0 / 3.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[6], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[6], ctype, cnodes, quad),
                 2.0 / 3.0,
                 rtol = _rtol,
             )
         end
 
         for degree in 4:8
+            quad = Quadrature(degree)
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[1], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[1], ctype, cnodes, quad),
                 1.0 / 15.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[2], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[2], ctype, cnodes, quad),
                 1.0 / 15.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[3] * λ(ξ)[3], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[3] * λ(ξ)[3], ctype, cnodes, quad),
                 1.0 / 15.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[4] * λ(ξ)[4], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[4] * λ(ξ)[4], ctype, cnodes, quad),
                 16.0 / 45.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[5] * λ(ξ)[5], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[5] * λ(ξ)[5], ctype, cnodes, quad),
                 16.0 / 45.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[6] * λ(ξ)[6], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[6] * λ(ξ)[6], ctype, cnodes, quad),
                 16.0 / 45.0,
                 rtol = _rtol,
             )
 
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[4], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[4], ctype, cnodes, quad),
                 0.0,
                 atol = _atol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[5], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[5], ctype, cnodes, quad),
                 -2.0 / 45.0,
                 rtol = _rtol,
             )
             @test isapprox(
-                integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[6], cnodes, ct, Quadrature(degree)),
+                Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[6], ctype, cnodes, quad),
                 0.0,
                 atol = _atol,
             )
@@ -160,15 +162,18 @@ end
         mesh = basic_mesh()
         c2n = connectivities_indices(mesh, :c2n)
         icell = 2 # Test integration on quad '2'
-        n = get_nodes(mesh, c2n[icell])
-        ct = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
 
         @test all(
-            isapprox(integrate(x -> 2.0, n, ct, Quadrature(degree)), 2.0) for degree in 1:13
+            isapprox(Bcube.integrate(x -> 2.0, ctype, cnodes, Quadrature(degree)), 2.0) for
+            degree in 1:13
         )
         @test all(
-            isapprox(integrate(x -> 2x[1] + 3x[2], n, ct, Quadrature(degree)), 4.5) for
-            degree in 1:13
+            isapprox(
+                Bcube.integrate(x -> 2x[1] + 3x[2], ctype, cnodes, Quadrature(degree)),
+                4.5,
+            ) for degree in 1:13
         )
 
         # An other quad
@@ -179,16 +184,17 @@ end
         mesh = one_cell_mesh(:quad; xmin, xmax, ymin, ymax)
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
+        ctype = cells(mesh)[1]
         fs = FunctionSpace(:Lagrange, 1)
-        λ = shape_functions(fs, shape(ct))
-        ∇λ = ξ -> grad_shape_functions(fs, Val(1), ct, cnodes, ξ)
+        λ = shape_functions(fs, shape(ctype))
+        ∇λ = ξ -> grad_shape_functions(fs, Val(1), ctype, cnodes, ξ)
         degree = Val(2)
         quad = Quadrature(degree)
-        @test integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[1], cnodes, ct, quad) ≈ Δx * Δy / 9
-        @test integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[2], cnodes, ct, quad) ≈ Δx * Δy / 18
-        @test integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[2], cnodes, ct, quad) ≈ Δx * Δy / 9
-        @test integrate_ref(ξ -> ∇λ(ξ)[1, :] ⋅ ∇λ(ξ)[1, :], cnodes, ct, quad) ≈
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[1], ctype, cnodes, quad) ≈ Δx * Δy / 9
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[1] * λ(ξ)[2], ctype, cnodes, quad) ≈
+              Δx * Δy / 18
+        @test Bcube.integrate_ref(ξ -> λ(ξ)[2] * λ(ξ)[2], ctype, cnodes, quad) ≈ Δx * Δy / 9
+        @test Bcube.integrate_ref(ξ -> ∇λ(ξ)[1, :] ⋅ ∇λ(ξ)[1, :], ctype, cnodes, quad) ≈
               (Δx^2 + Δy^2) / (3 * Δx * Δy)
     end
 
@@ -206,19 +212,19 @@ end
 
             for icell in (1, 2)
                 cnodes = get_nodes(mesh, c2n[icell])
-                ct = cells(mesh)[icell]
-                @test integrate(g, 1, cnodes, ct, quad) ≈ Δx
-                @test integrate(g, 2, cnodes, ct, quad) ≈ Δy
-                @test integrate(g, 3, cnodes, ct, quad) ≈ Δx
-                @test integrate(g, 4, cnodes, ct, quad) ≈ Δy
+                ctype = cells(mesh)[icell]
+                @test Bcube.integrate(g, 1, ctype, cnodes, quad) ≈ Δx
+                @test Bcube.integrate(g, 2, ctype, cnodes, quad) ≈ Δy
+                @test Bcube.integrate(g, 3, ctype, cnodes, quad) ≈ Δx
+                @test Bcube.integrate(g, 4, ctype, cnodes, quad) ≈ Δy
             end
 
             icell = 3
             cnodes = get_nodes(mesh, c2n[icell])
-            ct = cells(mesh)[icell]
-            @test integrate(g, 1, cnodes, ct, quad) ≈ Δx
-            @test integrate(g, 2, cnodes, ct, quad) ≈ norm([Δx, Δy])
-            @test integrate(g, 3, cnodes, ct, quad) ≈ Δy
+            ctype = cells(mesh)[icell]
+            @test Bcube.integrate(g, 1, ctype, cnodes, quad) ≈ Δx
+            @test Bcube.integrate(g, 2, ctype, cnodes, quad) ≈ norm([Δx, Δy])
+            @test Bcube.integrate(g, 3, ctype, cnodes, quad) ≈ Δy
         end
     end
 
@@ -254,9 +260,9 @@ end
         # Test integration accuracy
         degquad = Val(200)
         quad = Quadrature(degquad)
-        @test integrate(x -> 1, lnodes, Bar3_t(), quad) ≈ L
-        @test integrate(x -> 1, 1, cnodes, ctype, quad) ≈ L
-        @test integrate_ref(x -> 1, lnodes, Bar3_t(), quad) ≈ L
+        @test Bcube.integrate(x -> 1, Bar3_t(), lnodes, quad) ≈ L
+        @test Bcube.integrate(x -> 1, 1, ctype, cnodes, quad) ≈ L
+        @test Bcube.integrate_ref(x -> 1, Bar3_t(), lnodes, quad) ≈ L
     end
 
     @testset "Sphere" begin
@@ -267,7 +273,7 @@ end
         S = sum(1:ncells(mesh)) do icell
             cnodes = get_nodes(mesh, c2n[icell])
             ctype = cells(mesh)[icell]
-            integrate_ref(ξ -> 1.0, cnodes, ctype, Quadrature(1))
+            Bcube.integrate_ref(ξ -> 1.0, ctype, cnodes, Quadrature(1))
         end
         @test isapprox(S, 4π; atol = 1e-1)
     end
@@ -276,15 +282,15 @@ end
         mesh = one_cell_mesh(:line)
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
+        ctype = cells(mesh)[1]
 
         g = x -> 2.5
-        @test integrate(g, 1, cnodes, ct, Quadrature(1)) ≈ 2.5
-        @test integrate(g, 2, cnodes, ct, Quadrature(1)) ≈ 2.5
+        @test Bcube.integrate(g, 1, ctype, cnodes, Quadrature(1)) ≈ 2.5
+        @test Bcube.integrate(g, 2, ctype, cnodes, Quadrature(1)) ≈ 2.5
 
         g = x -> x[1] # this is x -> x but since all nodes are in R^n, we need to select the component (as for triangles below)
-        @test integrate(g, 1, cnodes, ct, Quadrature(2)) ≈ -1.0
-        @test integrate(g, 2, cnodes, ct, Quadrature(2)) ≈ 1.0
+        @test Bcube.integrate(g, 1, ctype, cnodes, Quadrature(2)) ≈ -1.0
+        @test Bcube.integrate(g, 2, ctype, cnodes, Quadrature(2)) ≈ 1.0
 
         #--- NEW-API version
         cinfo = CellInfo(mesh, 1)
@@ -312,19 +318,19 @@ end
         mesh = one_cell_mesh(:tri; xmin = 0.0, ymin = 0.0)
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
+        ctype = cells(mesh)[1]
 
         # Test for constant
         g = x -> 2.5
-        @test integrate(g, 1, cnodes, ct, Quadrature(1)) ≈ 2.5
-        @test integrate(g, 2, cnodes, ct, Quadrature(1)) ≈ 2.5 * √(2.0)
-        @test integrate(g, 3, cnodes, ct, Quadrature(1)) ≈ 2.5
+        @test Bcube.integrate(g, 1, ctype, cnodes, Quadrature(1)) ≈ 2.5
+        @test Bcube.integrate(g, 2, ctype, cnodes, Quadrature(1)) ≈ 2.5 * √(2.0)
+        @test Bcube.integrate(g, 3, ctype, cnodes, Quadrature(1)) ≈ 2.5
 
         # Test for linear function
         g = x -> x[1] + x[2]
-        @test integrate(g, 1, cnodes, ct, Quadrature(2)) ≈ 0.5
-        @test integrate(g, 2, cnodes, ct, Quadrature(2)) ≈ √(2.0)
-        @test integrate(g, 3, cnodes, ct, Quadrature(2)) ≈ 0.5
+        @test Bcube.integrate(g, 1, ctype, cnodes, Quadrature(2)) ≈ 0.5
+        @test Bcube.integrate(g, 2, ctype, cnodes, Quadrature(2)) ≈ √(2.0)
+        @test Bcube.integrate(g, 3, ctype, cnodes, Quadrature(2)) ≈ 0.5
 
         #----- NEW-API version
         cinfo = CellInfo(mesh, 1)
@@ -479,11 +485,11 @@ end
 
     @testset "Lagrange cube" begin
         mesh = scale(translate(one_cell_mesh(:cube), [1.0, 1.0, 2.0]), 2.0)
-        @test integrate(x -> 1, mesh.nodes, cells(mesh)[1], Quadrature(1)) == 64
+        @test Bcube.integrate(x -> 1, cells(mesh)[1], mesh.nodes, Quadrature(1)) == 64
 
         mesh = one_cell_mesh(:cube)
         icell = 1
-        ct = cells(mesh)[icell]
+        ctype = cells(mesh)[icell]
         q = Quadrature(1)
         f(x) = 1
         ξηζ = SA[0.0, 0.0, 0.0]
@@ -494,10 +500,14 @@ end
             m = translate(mesh, rand(3))
             m = scale(m, s)
 
-            nodes = get_nodes(m)
+            cnodes = get_nodes(m)
 
-            @test isapprox_arrays(mapping_jacobian(nodes, ct, ξηζ), s .* I3; rtol = 1e-14)
-            @test isapprox(integrate(f, nodes, ct, q), 8 * s^3)
+            @test isapprox_arrays(
+                mapping_jacobian(cnodes, ctype, ξηζ),
+                s .* I3;
+                rtol = 1e-14,
+            )
+            @test isapprox(Bcube.integrate(f, ctype, cnodes, q), 8 * s^3)
         end
     end
 
@@ -516,7 +526,7 @@ end
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        @test integrate(x -> 1, cnodes, ctype, Quadrature(1)) == 0.75
+        @test Bcube.integrate(x -> 1, ctype, cnodes, Quadrature(1)) == 0.75
         dΩ = Measure(CellDomain(mesh), 2)
         g = PhysicalFunction(x -> 1)
         b = Bcube.compute(∫(g)dΩ)

--- a/test/integration/test_integration.jl
+++ b/test/integration/test_integration.jl
@@ -503,7 +503,7 @@ end
             cnodes = get_nodes(m)
 
             @test isapprox_arrays(
-                mapping_jacobian(cnodes, ctype, ξηζ),
+                Bcube.mapping_jacobian(cnodes, ctype, ξηζ),
                 s .* I3;
                 rtol = 1e-14,
             )

--- a/test/interpolation/test_cellfunction.jl
+++ b/test/interpolation/test_cellfunction.jl
@@ -223,7 +223,7 @@ end
         v2 = normalize(Bcube.coords(F) - Bcube.coords(E)) * 2
         u = normalize(Bcube.coords(C) - Bcube.coords(B))
         v2_in_1 = _R * v2
-        ν1 = Bcube.cell_normal(cnodes_n, ctype_n, ξ_n)
+        ν1 = Bcube.cell_normal(ctype_n, cnodes_n, ξ_n)
         @test v2 ⋅ u ≈ v2_in_1 ⋅ u
         @test abs(ν1 ⋅ v2_in_1) < 1e-16
 
@@ -231,7 +231,7 @@ end
         v1 = normalize(Bcube.coords(D) - Bcube.coords(B)) * 2
         u = normalize(Bcube.coords(C) - Bcube.coords(B))
         v1_in_2 = _R * v1
-        ν2 = Bcube.cell_normal(cnodes_p, ctype_p, ξ_p)
+        ν2 = Bcube.cell_normal(ctype_p, cnodes_p, ξ_p)
         @test v1 ⋅ u ≈ v1_in_2 ⋅ u
         @test abs(ν2 ⋅ v1_in_2) < 1e-16
 
@@ -275,7 +275,7 @@ end
         v2 = rot * normalize(Bcube.coords(F) - Bcube.coords(E)) * 2
         u = rot * normalize(Bcube.coords(C) - Bcube.coords(B))
         v2_in_1 = _R * v2
-        ν1 = Bcube.cell_normal(cnodes_n, ctype_n, ξ_n)
+        ν1 = Bcube.cell_normal(ctype_n, cnodes_n, ξ_n)
         @test v2 ⋅ u ≈ v2_in_1 ⋅ u
         @test abs(ν1 ⋅ v2_in_1) < 2e-15
 
@@ -283,7 +283,7 @@ end
         v1 = rot * normalize(Bcube.coords(D) - Bcube.coords(B)) * 2
         u = rot * normalize(Bcube.coords(C) - Bcube.coords(B))
         v1_in_2 = _R * v1
-        ν2 = Bcube.cell_normal(cnodes_p, ctype_p, ξ_p)
+        ν2 = Bcube.cell_normal(ctype_p, cnodes_p, ξ_p)
         @test v1 ⋅ u ≈ v1_in_2 ⋅ u
         @test abs(ν2 ⋅ v1_in_2) < 1e-16
     end

--- a/test/interpolation/test_lagrange.jl
+++ b/test/interpolation/test_lagrange.jl
@@ -101,13 +101,13 @@ end
         # TODO: the part below should be moved to test_ref2loc
         mesh = Mesh([Node([0.0]), Node([1.0])], [Bar2_t()], Connectivity([2], [1, 2]))
         cellTypes = cells(mesh)
-        ct = cellTypes[1]
+        ctype = cellTypes[1]
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        Finv = mapping_inv(cnodes, ct)
+        Finv = Bcube.mapping_inv(ctype, cnodes)
 
         interp = FunctionSpace(:Lagrange, 1)
-        ∇λ = x -> grad_shape_functions(interp, Val(1), ct, cnodes, Finv(x))
+        ∇λ = x -> grad_shape_functions(interp, Val(1), ctype, cnodes, Finv(x))
         @test ∇λ(0.5) ≈ reshape([-1.0, 1.0], (2, 1))
     end
 
@@ -211,7 +211,7 @@ end
         mesh =
             Mesh([Node(S1), Node(S2), Node(S3)], [Tri3_t()], Connectivity([3], [1, 2, 3]))
         cellTypes = cells(mesh)
-        ct = cellTypes[1]
+        ctype = cellTypes[1]
         c2n = connectivities_indices(mesh, :c2n)
         n = get_nodes(mesh, c2n[1])
 
@@ -219,7 +219,7 @@ end
             0.5 * abs((S2[1] - S1[1]) * (S3[2] - S1[2]) - (S3[1] - S1[1]) * (S2[2] - S1[1]))
 
         interp = FunctionSpace(:Lagrange, 1)
-        ∇λ = x -> grad_shape_functions(interp, Val(1), ct, n, x)
+        ∇λ = x -> grad_shape_functions(interp, Val(1), ctype, n, x)
         @test ∇λ([0, 0])[1, :] ≈ (0.5 / vol) * ([S2[2] - S3[2], S3[1] - S2[1]])
         @test ∇λ([0, 0])[2, :] ≈ (0.5 / vol) * ([S3[2] - S1[2], S1[1] - S3[1]])
         @test ∇λ([0, 0])[3, :] ≈ (0.5 / vol) * ([S1[2] - S2[2], S2[1] - S1[1]])

--- a/test/interpolation/test_projection.jl
+++ b/test/interpolation/test_projection.jl
@@ -40,9 +40,9 @@
         xmax = 7.0
         mesh = one_cell_mesh(:line; xmin, xmax)
         cnodes = get_nodes(mesh)
-        ct = cells(mesh)[1]
-        Finv = mapping_inv(cnodes, ct)
-        xc = center(cnodes, ct)
+        ctype = cells(mesh)[1]
+        Finv = mapping_inv(cnodes, ctype)
+        xc = center(ctype, cnodes)
         fs = FunctionSpace(:Taylor, 1)
         fes = FESpace(fs, :discontinuous)
         u2 = CellVariable(:u, mesh, fes)
@@ -52,7 +52,7 @@
         q = projection(f, L2_projector(u2))
         #- compare the result vector + the resulting interpolation function
         @test all(q .≈ [f(xc), ForwardDiff.gradient(f, xc)[1] * (xmax - xmin)]) # q = [f(x0), f'(x0) dx]
-        λ = x -> shape_functions(fs, shape(ct), Finv(x))
+        λ = x -> shape_functions(fs, shape(ctype), Finv(x))
         uᵢ = interpolate(λ, q)
         @test all(uᵢ([x]) .≈ f([x]) for x in range(xmin, xmax; length = 5))
     end
@@ -73,7 +73,7 @@
 
         for icell in 1:ncells(mesh)
             # Alias for cell type
-            ct = cellTypes[icell]
+            ctype = cellTypes[icell]
 
             # Alias for nodes
             n = get_nodes(mesh, c2n[icell])
@@ -84,7 +84,7 @@
             S = [S1, S2, S3]
 
             # Corresponding shape
-            s = shape(ct)
+            s = shape(ctype)
 
             λ = x -> shape_functions(fSpace, s, x)
 

--- a/test/interpolation/test_projection.jl
+++ b/test/interpolation/test_projection.jl
@@ -41,7 +41,7 @@
         mesh = one_cell_mesh(:line; xmin, xmax)
         cnodes = get_nodes(mesh)
         ctype = cells(mesh)[1]
-        Finv = mapping_inv(cnodes, ctype)
+        Finv = Bcube.mapping_inv(ctype, cnodes)
         xc = center(ctype, cnodes)
         fs = FunctionSpace(:Taylor, 1)
         fes = FESpace(fs, :discontinuous)

--- a/test/mapping/test_mapping.jl
+++ b/test/mapping/test_mapping.jl
@@ -14,29 +14,29 @@
         c2n = connectivities_indices(mesh, :c2n)
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        @test isapprox_arrays(mapping(ctype, cnodes, [-1.0]), [xmin]; rtol = tol)
-        @test isapprox_arrays(mapping(ctype, cnodes, [1.0]), [xmax]; rtol = tol)
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [-1.0]), [xmin]; rtol = tol)
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [1.0]), [xmax]; rtol = tol)
         @test isapprox_arrays(
-            mapping_jacobian(cnodes, ctype, rand(1)),
+            Bcube.mapping_jacobian(cnodes, ctype, rand(1)),
             @SVector[(xmax - xmin) / 2.0];
             rtol = tol,
         )
         @test isapprox(
-            mapping_det_jacobian(cnodes, ctype, rand(1)),
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(1)),
             (xmax - xmin) / 2.0,
             rtol = tol,
         )
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, xmin), SA[-1.0], rtol = tol)
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, xmax), SA[1.0], rtol = tol)
+        @test isapprox_arrays(Bcube.mapping_inv(ctype, cnodes, xmin), SA[-1.0], rtol = tol)
+        @test isapprox_arrays(Bcube.mapping_inv(ctype, cnodes, xmax), SA[1.0], rtol = tol)
 
         # Line order 2 -> no mapping yet, uncomment when mapping is available
         #mesh = scale(one_cell_mesh(:line; order = 2), rand())
         #c2n = connectivities_indices(mesh,:c2n)
         #ct = cells(mesh)[icell]
         #n = get_nodes(mesh, c2n[icell])
-        #@test mapping(n, ct, [-1.]) == coords(n[1])
-        #@test mapping(n, ct, [ 1.]) == coords(n[2])
-        #@test mapping(n, ct, [ 0.]) == coords(n[3])
+        #@test Bcube.mapping(n, ct, [-1.]) == coords(n[1])
+        #@test Bcube.mapping(n, ct, [ 1.]) == coords(n[2])
+        #@test Bcube.mapping(n, ct, [ 0.]) == coords(n[3])
 
         # Triangle order 1
         xmin, ymin = -rand(2)
@@ -48,24 +48,36 @@
         x1 = [xmin, ymin]
         x2 = [xmax, ymin]
         x3 = [xmin, ymax]
-        @test isapprox(mapping(ctype, cnodes, [0.0, 0.0]), x1, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), x1, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
         @test isapprox_arrays(
-            mapping_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_jacobian(cnodes, ctype, rand(2)),
             SA[
                 (xmax-xmin) 0.0
                 0.0 (ymax-ymin)
             ],
         )
         @test isapprox(
-            mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin),
             rtol = eps(),
         )
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x1), SA[0.0, 0.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x2), SA[1.0, 0.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x3), SA[0.0, 1.0]; rtol = tol)
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, x1),
+            SA[0.0, 0.0];
+            rtol = tol,
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, x2),
+            SA[1.0, 0.0];
+            rtol = tol,
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, x3),
+            SA[0.0, 1.0];
+            rtol = tol,
+        )
 
         # Triangle order 2
         xmin, ymin = -rand(2)
@@ -80,14 +92,14 @@
         x4 = (x1 + x2) / 2
         x5 = (x2 + x3) / 2
         x6 = (x3 + x1) / 2
-        @test isapprox(mapping(ctype, cnodes, [0.0, 0.0]), x1, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.5, 0.0]), x4, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.5, 0.5]), x5, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.0, 0.5]), x6, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), x1, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.5, 0.0]), x4, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.5, 0.5]), x5, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 0.5]), x6, rtol = eps())
         @test isapprox(
-            mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin),
         )
 
@@ -102,26 +114,42 @@
         x2 = [xmax, ymin]
         x3 = [xmax, ymax]
         x4 = [xmin, ymax]
-        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0]), x1, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0]), x2, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, -1.0]), x1, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, -1.0]), x2, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
         @test isapprox(
-            mapping_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_jacobian(cnodes, ctype, rand(2)),
             SA[
                 (xmax-xmin) 0.0
                 0.0 (ymax-ymin)
             ] / 2.0,
         )
         @test isapprox(
-            mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = tol,
         )
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x1), SA[-1.0, -1.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x2), SA[1.0, -1.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x3), SA[1.0, 1.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, x4), SA[-1.0, 1.0]; rtol = tol)
+        @test isapprox_arrays(
+            Bcube.Bcube.mapping_inv(ctype, cnodes, x1),
+            SA[-1.0, -1.0];
+            rtol = tol,
+        )
+        @test isapprox_arrays(
+            Bcube.Bcube.mapping_inv(ctype, cnodes, x2),
+            SA[1.0, -1.0];
+            rtol = tol,
+        )
+        @test isapprox_arrays(
+            Bcube.Bcube.mapping_inv(ctype, cnodes, x3),
+            SA[1.0, 1.0];
+            rtol = tol,
+        )
+        @test isapprox_arrays(
+            Bcube.Bcube.mapping_inv(ctype, cnodes, x4),
+            SA[-1.0, 1.0];
+            rtol = tol,
+        )
 
         θ = π / 5
         s = 3
@@ -132,7 +160,7 @@
         c = CellInfo(mesh, 1)
         cnodes = nodes(c)
         ctype = Bcube.celltype(c)
-        @test all(mapping_jacobian_inv(cnodes, ctype, SA[0.0, 0.0]) .≈ R(-θ) ./ s)
+        @test all(Bcube.mapping_jacobian_inv(cnodes, ctype, SA[0.0, 0.0]) .≈ R(-θ) ./ s)
 
         # Quad order 2
         xmin, ymin = -rand(2)
@@ -150,17 +178,17 @@
         x7 = (x3 + x4) / 2
         x8 = (x4 + x1) / 2
         x9 = [(xmin + xmax) / 2, (ymin + ymax) / 2]
-        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0]), x1, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0]), x2, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.0, -1.0]), x5, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [1.0, 0.0]), x6, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.0, 1.0]), x7, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [-1.0, 0.0]), x8, rtol = eps())
-        @test isapprox(mapping(ctype, cnodes, [0.0, 0.0]), x9, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, -1.0]), x1, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, -1.0]), x2, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, -1.0]), x5, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 0.0]), x6, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 1.0]), x7, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, 0.0]), x8, rtol = eps())
+        @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), x9, rtol = eps())
         @test isapprox(
-            mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = 1000eps(),
         )
@@ -173,40 +201,72 @@
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
         tol = 1e-15
-        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0]), cnodes[1].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0]), cnodes[2].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0]), cnodes[3].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0]), cnodes[4].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [-1.0 / 3.0, -1.0]), cnodes[5].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [1.0 / 3.0, -1.0]), cnodes[6].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0 / 3.0]), cnodes[7].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0 / 3.0]), cnodes[8].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [1.0 / 3, 1.0]), cnodes[9].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [-1.0 / 3, 1.0]), cnodes[10].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0 / 3.0]), cnodes[11].x, rtol = tol)
-        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0 / 3.0]), cnodes[12].x, rtol = tol)
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, -1.0]), cnodes[1].x, rtol = tol)
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, -1.0]), cnodes[2].x, rtol = tol)
+        @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 1.0]), cnodes[3].x, rtol = tol)
+        @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, 1.0]), cnodes[4].x, rtol = tol)
         @test isapprox(
-            mapping(ctype, cnodes, [-1.0 / 3.0, -1.0 / 3.0]),
+            Bcube.mapping(ctype, cnodes, [-1.0 / 3.0, -1.0]),
+            cnodes[5].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [1.0 / 3.0, -1.0]),
+            cnodes[6].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [1.0, -1.0 / 3.0]),
+            cnodes[7].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [1.0, 1.0 / 3.0]),
+            cnodes[8].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [1.0 / 3, 1.0]),
+            cnodes[9].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [-1.0 / 3, 1.0]),
+            cnodes[10].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [-1.0, 1.0 / 3.0]),
+            cnodes[11].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [-1.0, -1.0 / 3.0]),
+            cnodes[12].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            Bcube.mapping(ctype, cnodes, [-1.0 / 3.0, -1.0 / 3.0]),
             cnodes[13].x,
             rtol = tol,
         )
         @test isapprox(
-            mapping(ctype, cnodes, [1.0 / 3.0, -1.0 / 3.0]),
+            Bcube.mapping(ctype, cnodes, [1.0 / 3.0, -1.0 / 3.0]),
             cnodes[14].x,
             rtol = tol,
         )
         @test isapprox(
-            mapping(ctype, cnodes, [1.0 / 3.0, 1.0 / 3.0]),
+            Bcube.mapping(ctype, cnodes, [1.0 / 3.0, 1.0 / 3.0]),
             cnodes[15].x,
             rtol = tol,
         )
         @test isapprox(
-            mapping(ctype, cnodes, [-1.0 / 3.0, 1.0 / 3.0]),
+            Bcube.mapping(ctype, cnodes, [-1.0 / 3.0, 1.0 / 3.0]),
             cnodes[16].x,
             rtol = tol,
         )
         @test isapprox(
-            mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = 1000eps(),
         )
@@ -225,7 +285,7 @@
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        F = mapping(ctype, cnodes)
+        F = Bcube.mapping(ctype, cnodes)
         @test isapprox_arrays(F([-1.0, -1.0, -1.0]), [1.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, -1.0, -1.0]), [2.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, 1.0, -1.0]), [2.0, 2.0, 1.0])
@@ -251,7 +311,7 @@
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        F = mapping(ctype, cnodes)
+        F = Bcube.mapping(ctype, cnodes)
         @test isapprox_arrays(F([-1.0, -1.0, -1.0]), [1.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, -1.0, -1.0]), [2.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, 1.0, -1.0]), [2.0, 2.0, 1.0])
@@ -275,7 +335,7 @@
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        F = mapping(ctype, cnodes)
+        F = Bcube.mapping(ctype, cnodes)
         @test isapprox_arrays(F([0.0, 0.0, -1.0]), [1.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, 0.0, -1.0]), [2.0, 1.0, 1.0])
         @test isapprox_arrays(F([0.0, 1.0, -1.0]), [1.0, 2.0, 1.0])
@@ -291,26 +351,42 @@
         # Get cell -> node connectivity from mesh
         c2n = connectivities_indices(mesh, :c2n)
 
-        # Test mapping on quad '2'
+        # Test Bcube.mapping on quad '2'
         icell = 2
         cnodes = get_nodes(mesh, c2n[icell])
         ctype = cells(mesh)[icell]
         center = sum(y -> coords(y), cnodes) / length(cnodes)
-        @test isapprox_arrays(mapping(ctype, cnodes, [-1.0, -1.0]), coords(cnodes[1]))
-        @test isapprox_arrays(mapping(ctype, cnodes, [1.0, -1.0]), coords(cnodes[2]))
-        @test isapprox_arrays(mapping(ctype, cnodes, [1.0, 1.0]), coords(cnodes[3]))
-        @test isapprox_arrays(mapping(ctype, cnodes, [-1.0, 1.0]), coords(cnodes[4]))
-        @test isapprox_arrays(mapping(ctype, cnodes, [0.0, 0.0]), center)
-        @test isapprox(mapping_det_jacobian(cnodes, ctype, rand(2)), 0.25, rtol = eps())
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [-1.0, -1.0]), coords(cnodes[1]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [1.0, -1.0]), coords(cnodes[2]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [1.0, 1.0]), coords(cnodes[3]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [-1.0, 1.0]), coords(cnodes[4]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), center)
+        @test isapprox(
+            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            0.25,
+            rtol = eps(),
+        )
 
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[1])), [-1.0, -1.0])
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[2])), [1.0, -1.0])
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[3])), [1.0, 1.0])
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[4])), [-1.0, 1.0])
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, center), [0.0, 0.0])
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[1])),
+            [-1.0, -1.0],
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[2])),
+            [1.0, -1.0],
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[3])),
+            [1.0, 1.0],
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[4])),
+            [-1.0, 1.0],
+        )
+        @test isapprox_arrays(Bcube.mapping_inv(ctype, cnodes, center), [0.0, 0.0])
         x = coords(cnodes[1])
         @test isapprox(
-            mapping(ctype, cnodes, mapping_inv(cnodes, ctype, x)),
+            Bcube.mapping(ctype, cnodes, Bcube.mapping_inv(ctype, cnodes, x)),
             x,
             rtol = eps(eltype(x)),
         )
@@ -320,27 +396,36 @@
         cnodes = get_nodes(mesh, c2n[icell])
         ctype = cells(mesh)[icell]
         center = sum(y -> coords(y), cnodes) / length(cnodes)
-        @test isapprox_arrays(mapping(ctype, cnodes, [0.0, 0.0]), coords(cnodes[1]))
-        @test isapprox_arrays(mapping(ctype, cnodes, [1.0, 0.0]), coords(cnodes[2]))
-        @test isapprox_arrays(mapping(ctype, cnodes, [0.0, 1.0]), coords(cnodes[3]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), coords(cnodes[1]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [1.0, 0.0]), coords(cnodes[2]))
+        @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [0.0, 1.0]), coords(cnodes[3]))
         @test isapprox(
-            mapping(ctype, cnodes, [1 / 3, 1 / 3]),
+            Bcube.mapping(ctype, cnodes, [1 / 3, 1 / 3]),
             center,
             rtol = eps(eltype(center)),
         )
-        @test isapprox(mapping_det_jacobian(cnodes, ctype, 0.0), 1.0, rtol = eps())
+        @test isapprox(Bcube.mapping_det_jacobian(cnodes, ctype, 0.0), 1.0, rtol = eps())
 
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[1])), [0.0, 0.0])
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[2])), [1.0, 0.0])
-        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[3])), [0.0, 1.0])
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[1])),
+            [0.0, 0.0],
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[2])),
+            [1.0, 0.0],
+        )
+        @test isapprox_arrays(
+            Bcube.mapping_inv(ctype, cnodes, coords(cnodes[3])),
+            [0.0, 1.0],
+        )
         @test isapprox(
-            mapping_inv(cnodes, ctype, center),
+            Bcube.mapping_inv(ctype, cnodes, center),
             [1 / 3, 1 / 3],
             rtol = 10 * eps(eltype(x)),
         )
         x = coords(cnodes[1])
         @test isapprox(
-            mapping(ctype, cnodes, mapping_inv(cnodes, ctype, x)),
+            Bcube.mapping(ctype, cnodes, Bcube.mapping_inv(ctype, cnodes, x)),
             x,
             rtol = eps(eltype(x)),
         )
@@ -360,23 +445,23 @@
             ftype = faceTypes[kface]
             fshape = shape(ftype)
             fnodes = get_nodes(mesh, f2n[kface])
-            Fface = mapping(ftype, fnodes)
+            Fface = Bcube.mapping(ftype, fnodes)
 
             # Neighbor cell i
             i = f2c[kface][1]
             xᵢ = get_nodes(mesh, c2n[i])
             ctᵢ = cellTypes[i]
             shapeᵢ = shape(ctᵢ)
-            Fᵢ = mapping(ctᵢ, xᵢ)
+            Fᵢ = Bcube.mapping(ctᵢ, xᵢ)
             sideᵢ = cell_side(ctᵢ, c2n[i], f2n[kface])
-            fpᵢ = mapping_face(shapeᵢ, sideᵢ) # mapping face-ref -> cell_i-ref
+            fpᵢ = Bcube.mapping_face(shapeᵢ, sideᵢ) # Bcube.mapping face-ref -> cell_i-ref
 
             # Neighbor cell j
             j = f2c[kface][2]
             xⱼ = get_nodes(mesh, c2n[j])
             ctⱼ = cellTypes[j]
             shapeⱼ = shape(ctⱼ)
-            Fⱼ = mapping(ctⱼ, xⱼ)
+            Fⱼ = Bcube.mapping(ctⱼ, xⱼ)
             sideⱼ = cell_side(ctⱼ, c2n[j], f2n[kface])
             # This part is a bit tricky : we want the face parametrization (face-ref -> cell-ref) on
             # side `j`. For this, we need to know the permutation between the vertices of `kface` and the
@@ -397,7 +482,7 @@
             iglob_vertices_of_face_of_cell_j =
                 [c2n[j][faces2nodes(ctⱼ, sideⱼ)[l]] for l in 1:nv]
             g2l = indexin(f2n[kface][1:nv], iglob_vertices_of_face_of_cell_j)
-            fpⱼ = mapping_face(shapeⱼ, sideⱼ, g2l)
+            fpⱼ = Bcube.mapping_face(shapeⱼ, sideⱼ, g2l)
 
             # High-level API
             faceInfo = Bcube.FaceInfo(mesh, kface)

--- a/test/mapping/test_mapping.jl
+++ b/test/mapping/test_mapping.jl
@@ -17,7 +17,7 @@
         @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [-1.0]), [xmin]; rtol = tol)
         @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [1.0]), [xmax]; rtol = tol)
         @test isapprox_arrays(
-            Bcube.mapping_jacobian(cnodes, ctype, rand(1)),
+            Bcube.mapping_jacobian(ctype, cnodes, rand(1)),
             @SVector[(xmax - xmin) / 2.0];
             rtol = tol,
         )
@@ -52,7 +52,7 @@
         @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
         @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
         @test isapprox_arrays(
-            Bcube.mapping_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_jacobian(ctype, cnodes, rand(2)),
             SA[
                 (xmax-xmin) 0.0
                 0.0 (ymax-ymin)
@@ -119,7 +119,7 @@
         @test isapprox(Bcube.mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
         @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
         @test isapprox(
-            Bcube.mapping_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_jacobian(ctype, cnodes, rand(2)),
             SA[
                 (xmax-xmin) 0.0
                 0.0 (ymax-ymin)

--- a/test/mapping/test_mapping.jl
+++ b/test/mapping/test_mapping.jl
@@ -160,7 +160,7 @@
         c = CellInfo(mesh, 1)
         cnodes = nodes(c)
         ctype = Bcube.celltype(c)
-        @test all(Bcube.mapping_jacobian_inv(cnodes, ctype, SA[0.0, 0.0]) .≈ R(-θ) ./ s)
+        @test all(Bcube.mapping_jacobian_inv(ctype, cnodes, SA[0.0, 0.0]) .≈ R(-θ) ./ s)
 
         # Quad order 2
         xmin, ymin = -rand(2)

--- a/test/mapping/test_mapping.jl
+++ b/test/mapping/test_mapping.jl
@@ -22,7 +22,7 @@
             rtol = tol,
         )
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(1)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(1)),
             (xmax - xmin) / 2.0,
             rtol = tol,
         )
@@ -59,7 +59,7 @@
             ],
         )
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(2)),
             (xmax - xmin) * (ymax - ymin),
             rtol = eps(),
         )
@@ -99,7 +99,7 @@
         @test isapprox(Bcube.mapping(ctype, cnodes, [0.5, 0.5]), x5, rtol = eps())
         @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 0.5]), x6, rtol = eps())
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(2)),
             (xmax - xmin) * (ymax - ymin),
         )
 
@@ -126,7 +126,7 @@
             ] / 2.0,
         )
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = tol,
         )
@@ -188,7 +188,7 @@
         @test isapprox(Bcube.mapping(ctype, cnodes, [-1.0, 0.0]), x8, rtol = eps())
         @test isapprox(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), x9, rtol = eps())
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = 1000eps(),
         )
@@ -266,7 +266,7 @@
             rtol = tol,
         )
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = 1000eps(),
         )
@@ -362,7 +362,7 @@
         @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [-1.0, 1.0]), coords(cnodes[4]))
         @test isapprox_arrays(Bcube.mapping(ctype, cnodes, [0.0, 0.0]), center)
         @test isapprox(
-            Bcube.mapping_det_jacobian(cnodes, ctype, rand(2)),
+            Bcube.mapping_det_jacobian(ctype, cnodes, rand(2)),
             0.25,
             rtol = eps(),
         )
@@ -404,7 +404,7 @@
             center,
             rtol = eps(eltype(center)),
         )
-        @test isapprox(Bcube.mapping_det_jacobian(cnodes, ctype, 0.0), 1.0, rtol = eps())
+        @test isapprox(Bcube.mapping_det_jacobian(ctype, cnodes, 0.0), 1.0, rtol = eps())
 
         @test isapprox_arrays(
             Bcube.mapping_inv(ctype, cnodes, coords(cnodes[1])),

--- a/test/mapping/test_mapping.jl
+++ b/test/mapping/test_mapping.jl
@@ -12,22 +12,22 @@
         xmax = 1.0 + rand()
         mesh = one_cell_mesh(:line; xmin, xmax, order = 1)
         c2n = connectivities_indices(mesh, :c2n)
-        ct = cells(mesh)[icell]
-        n = get_nodes(mesh, c2n[icell])
-        @test isapprox_arrays(mapping(n, ct, [-1.0]), [xmin]; rtol = tol)
-        @test isapprox_arrays(mapping(n, ct, [1.0]), [xmax]; rtol = tol)
+        ctype = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
+        @test isapprox_arrays(mapping(ctype, cnodes, [-1.0]), [xmin]; rtol = tol)
+        @test isapprox_arrays(mapping(ctype, cnodes, [1.0]), [xmax]; rtol = tol)
         @test isapprox_arrays(
-            mapping_jacobian(n, ct, rand(1)),
+            mapping_jacobian(cnodes, ctype, rand(1)),
             @SVector[(xmax - xmin) / 2.0];
             rtol = tol,
         )
         @test isapprox(
-            mapping_det_jacobian(n, ct, rand(1)),
+            mapping_det_jacobian(cnodes, ctype, rand(1)),
             (xmax - xmin) / 2.0,
             rtol = tol,
         )
-        @test isapprox_arrays(mapping_inv(n, ct, xmin), SA[-1.0], rtol = tol)
-        @test isapprox_arrays(mapping_inv(n, ct, xmax), SA[1.0], rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, xmin), SA[-1.0], rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, xmax), SA[1.0], rtol = tol)
 
         # Line order 2 -> no mapping yet, uncomment when mapping is available
         #mesh = scale(one_cell_mesh(:line; order = 2), rand())
@@ -43,82 +43,85 @@
         xmax, ymax = rand(2)
         mesh = one_cell_mesh(:triangle; xmin, xmax, ymin, ymax, order = 1)
         c2n = connectivities_indices(mesh, :c2n)
-        ct = cells(mesh)[icell]
-        n = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
         x1 = [xmin, ymin]
         x2 = [xmax, ymin]
         x3 = [xmin, ymax]
-        @test isapprox(mapping(n, ct, [0.0, 0.0]), x1, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, 0.0]), x2, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.0, 1.0]), x3, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, 0.0]), x1, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
         @test isapprox_arrays(
-            mapping_jacobian(n, ct, rand(2)),
+            mapping_jacobian(cnodes, ctype, rand(2)),
             SA[
                 (xmax-xmin) 0.0
                 0.0 (ymax-ymin)
             ],
         )
         @test isapprox(
-            mapping_det_jacobian(n, ct, rand(2)),
+            mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin),
             rtol = eps(),
         )
-        @test isapprox_arrays(mapping_inv(n, ct, x1), SA[0.0, 0.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(n, ct, x2), SA[1.0, 0.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(n, ct, x3), SA[0.0, 1.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x1), SA[0.0, 0.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x2), SA[1.0, 0.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x3), SA[0.0, 1.0]; rtol = tol)
 
         # Triangle order 2
         xmin, ymin = -rand(2)
         xmax, ymax = rand(2)
         mesh = one_cell_mesh(:triangle; xmin, xmax, ymin, ymax, order = 2)
         c2n = connectivities_indices(mesh, :c2n)
-        ct = cells(mesh)[icell]
-        n = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
         x1 = [xmin, ymin]
         x2 = [xmax, ymin]
         x3 = [xmin, ymax]
         x4 = (x1 + x2) / 2
         x5 = (x2 + x3) / 2
         x6 = (x3 + x1) / 2
-        @test isapprox(mapping(n, ct, [0.0, 0.0]), x1, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, 0.0]), x2, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.0, 1.0]), x3, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.5, 0.0]), x4, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.5, 0.5]), x5, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.0, 0.5]), x6, rtol = eps())
-        @test isapprox(mapping_det_jacobian(n, ct, rand(2)), (xmax - xmin) * (ymax - ymin))
+        @test isapprox(mapping(ctype, cnodes, [0.0, 0.0]), x1, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, 0.0]), x2, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, 1.0]), x3, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.5, 0.0]), x4, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.5, 0.5]), x5, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, 0.5]), x6, rtol = eps())
+        @test isapprox(
+            mapping_det_jacobian(cnodes, ctype, rand(2)),
+            (xmax - xmin) * (ymax - ymin),
+        )
 
         # Quad order 1
         xmin, ymin = -rand(2)
         xmax, ymax = rand(2)
         mesh = one_cell_mesh(:quad; xmin, xmax, ymin, ymax, order = 1)
         c2n = connectivities_indices(mesh, :c2n)
-        ct = cells(mesh)[icell]
-        n = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
         x1 = [xmin, ymin]
         x2 = [xmax, ymin]
         x3 = [xmax, ymax]
         x4 = [xmin, ymax]
-        @test isapprox(mapping(n, ct, [-1.0, -1.0]), x1, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, -1.0]), x2, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, 1.0]), x3, rtol = eps())
-        @test isapprox(mapping(n, ct, [-1.0, 1.0]), x4, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0]), x1, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0]), x2, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
         @test isapprox(
-            mapping_jacobian(n, ct, rand(2)),
+            mapping_jacobian(cnodes, ctype, rand(2)),
             SA[
                 (xmax-xmin) 0.0
                 0.0 (ymax-ymin)
             ] / 2.0,
         )
         @test isapprox(
-            mapping_det_jacobian(n, ct, rand(2)),
+            mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = tol,
         )
-        @test isapprox_arrays(mapping_inv(n, ct, x1), SA[-1.0, -1.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(n, ct, x2), SA[1.0, -1.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(n, ct, x3), SA[1.0, 1.0]; rtol = tol)
-        @test isapprox_arrays(mapping_inv(n, ct, x4), SA[-1.0, 1.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x1), SA[-1.0, -1.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x2), SA[1.0, -1.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x3), SA[1.0, 1.0]; rtol = tol)
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, x4), SA[-1.0, 1.0]; rtol = tol)
 
         θ = π / 5
         s = 3
@@ -136,8 +139,8 @@
         xmax, ymax = rand(2)
         mesh = one_cell_mesh(:quad; xmin, xmax, ymin, ymax, order = 2)
         c2n = connectivities_indices(mesh, :c2n)
-        ct = cells(mesh)[icell]
-        n = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
         x1 = [xmin, ymin]
         x2 = [xmax, ymin]
         x3 = [xmax, ymax]
@@ -147,17 +150,17 @@
         x7 = (x3 + x4) / 2
         x8 = (x4 + x1) / 2
         x9 = [(xmin + xmax) / 2, (ymin + ymax) / 2]
-        @test isapprox(mapping(n, ct, [-1.0, -1.0]), x1, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, -1.0]), x2, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, 1.0]), x3, rtol = eps())
-        @test isapprox(mapping(n, ct, [-1.0, 1.0]), x4, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.0, -1.0]), x5, rtol = eps())
-        @test isapprox(mapping(n, ct, [1.0, 0.0]), x6, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.0, 1.0]), x7, rtol = eps())
-        @test isapprox(mapping(n, ct, [-1.0, 0.0]), x8, rtol = eps())
-        @test isapprox(mapping(n, ct, [0.0, 0.0]), x9, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0]), x1, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0]), x2, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0]), x3, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0]), x4, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, -1.0]), x5, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [1.0, 0.0]), x6, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, 1.0]), x7, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [-1.0, 0.0]), x8, rtol = eps())
+        @test isapprox(mapping(ctype, cnodes, [0.0, 0.0]), x9, rtol = eps())
         @test isapprox(
-            mapping_det_jacobian(n, ct, rand(2)),
+            mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = 1000eps(),
         )
@@ -167,27 +170,43 @@
         xmax, ymax = rand(2)
         mesh = one_cell_mesh(:quad; xmin, xmax, ymin, ymax, order = 3)
         c2n = connectivities_indices(mesh, :c2n)
-        ct = cells(mesh)[icell]
-        n = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        cnodes = get_nodes(mesh, c2n[icell])
         tol = 1e-15
-        @test isapprox(mapping(n, ct, [-1.0, -1.0]), n[1].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0, -1.0]), n[2].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0, 1.0]), n[3].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0, 1.0]), n[4].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0 / 3.0, -1.0]), n[5].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0 / 3.0, -1.0]), n[6].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0, -1.0 / 3.0]), n[7].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0, 1.0 / 3.0]), n[8].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0 / 3, 1.0]), n[9].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0 / 3, 1.0]), n[10].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0, 1.0 / 3.0]), n[11].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0, -1.0 / 3.0]), n[12].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0 / 3.0, -1.0 / 3.0]), n[13].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0 / 3.0, -1.0 / 3.0]), n[14].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [1.0 / 3.0, 1.0 / 3.0]), n[15].x, rtol = tol)
-        @test isapprox(mapping(n, ct, [-1.0 / 3.0, 1.0 / 3.0]), n[16].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0]), cnodes[1].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0]), cnodes[2].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0]), cnodes[3].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0]), cnodes[4].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [-1.0 / 3.0, -1.0]), cnodes[5].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [1.0 / 3.0, -1.0]), cnodes[6].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [1.0, -1.0 / 3.0]), cnodes[7].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [1.0, 1.0 / 3.0]), cnodes[8].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [1.0 / 3, 1.0]), cnodes[9].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [-1.0 / 3, 1.0]), cnodes[10].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [-1.0, 1.0 / 3.0]), cnodes[11].x, rtol = tol)
+        @test isapprox(mapping(ctype, cnodes, [-1.0, -1.0 / 3.0]), cnodes[12].x, rtol = tol)
         @test isapprox(
-            mapping_det_jacobian(n, ct, rand(2)),
+            mapping(ctype, cnodes, [-1.0 / 3.0, -1.0 / 3.0]),
+            cnodes[13].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            mapping(ctype, cnodes, [1.0 / 3.0, -1.0 / 3.0]),
+            cnodes[14].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            mapping(ctype, cnodes, [1.0 / 3.0, 1.0 / 3.0]),
+            cnodes[15].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            mapping(ctype, cnodes, [-1.0 / 3.0, 1.0 / 3.0]),
+            cnodes[16].x,
+            rtol = tol,
+        )
+        @test isapprox(
+            mapping_det_jacobian(cnodes, ctype, rand(2)),
             (xmax - xmin) * (ymax - ymin) / 4.0,
             rtol = 1000eps(),
         )
@@ -206,7 +225,7 @@
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        F = mapping(cnodes, ctype)
+        F = mapping(ctype, cnodes)
         @test isapprox_arrays(F([-1.0, -1.0, -1.0]), [1.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, -1.0, -1.0]), [2.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, 1.0, -1.0]), [2.0, 2.0, 1.0])
@@ -232,7 +251,7 @@
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        F = mapping(cnodes, ctype)
+        F = mapping(ctype, cnodes)
         @test isapprox_arrays(F([-1.0, -1.0, -1.0]), [1.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, -1.0, -1.0]), [2.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, 1.0, -1.0]), [2.0, 2.0, 1.0])
@@ -256,7 +275,7 @@
         icell = 1
         ctype = cells(mesh)[icell]
         cnodes = get_nodes(mesh, c2n[icell])
-        F = mapping(cnodes, ctype)
+        F = mapping(ctype, cnodes)
         @test isapprox_arrays(F([0.0, 0.0, -1.0]), [1.0, 1.0, 1.0])
         @test isapprox_arrays(F([1.0, 0.0, -1.0]), [2.0, 1.0, 1.0])
         @test isapprox_arrays(F([0.0, 1.0, -1.0]), [1.0, 2.0, 1.0])
@@ -274,45 +293,57 @@
 
         # Test mapping on quad '2'
         icell = 2
-        n = get_nodes(mesh, c2n[icell])
-        ct = cells(mesh)[icell]
-        center = sum(y -> coords(y), n) / length(n)
-        @test isapprox_arrays(mapping(n, ct, [-1.0, -1.0]), coords(n[1]))
-        @test isapprox_arrays(mapping(n, ct, [1.0, -1.0]), coords(n[2]))
-        @test isapprox_arrays(mapping(n, ct, [1.0, 1.0]), coords(n[3]))
-        @test isapprox_arrays(mapping(n, ct, [-1.0, 1.0]), coords(n[4]))
-        @test isapprox_arrays(mapping(n, ct, [0.0, 0.0]), center)
-        @test isapprox(mapping_det_jacobian(n, ct, rand(2)), 0.25, rtol = eps())
+        cnodes = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        center = sum(y -> coords(y), cnodes) / length(cnodes)
+        @test isapprox_arrays(mapping(ctype, cnodes, [-1.0, -1.0]), coords(cnodes[1]))
+        @test isapprox_arrays(mapping(ctype, cnodes, [1.0, -1.0]), coords(cnodes[2]))
+        @test isapprox_arrays(mapping(ctype, cnodes, [1.0, 1.0]), coords(cnodes[3]))
+        @test isapprox_arrays(mapping(ctype, cnodes, [-1.0, 1.0]), coords(cnodes[4]))
+        @test isapprox_arrays(mapping(ctype, cnodes, [0.0, 0.0]), center)
+        @test isapprox(mapping_det_jacobian(cnodes, ctype, rand(2)), 0.25, rtol = eps())
 
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[1])), [-1.0, -1.0])
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[2])), [1.0, -1.0])
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[3])), [1.0, 1.0])
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[4])), [-1.0, 1.0])
-        @test isapprox_arrays(mapping_inv(n, ct, center), [0.0, 0.0])
-        x = coords(n[1])
-        @test isapprox(mapping(n, ct, mapping_inv(n, ct, x)), x, rtol = eps(eltype(x)))
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[1])), [-1.0, -1.0])
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[2])), [1.0, -1.0])
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[3])), [1.0, 1.0])
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[4])), [-1.0, 1.0])
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, center), [0.0, 0.0])
+        x = coords(cnodes[1])
+        @test isapprox(
+            mapping(ctype, cnodes, mapping_inv(cnodes, ctype, x)),
+            x,
+            rtol = eps(eltype(x)),
+        )
 
         # Test mapping on triangle '3'
         icell = 3
-        n = get_nodes(mesh, c2n[icell])
-        ct = cells(mesh)[icell]
-        center = sum(y -> coords(y), n) / length(n)
-        @test isapprox_arrays(mapping(n, ct, [0.0, 0.0]), coords(n[1]))
-        @test isapprox_arrays(mapping(n, ct, [1.0, 0.0]), coords(n[2]))
-        @test isapprox_arrays(mapping(n, ct, [0.0, 1.0]), coords(n[3]))
-        @test isapprox(mapping(n, ct, [1 / 3, 1 / 3]), center, rtol = eps(eltype(center)))
-        @test isapprox(mapping_det_jacobian(n, ct, 0.0), 1.0, rtol = eps())
-
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[1])), [0.0, 0.0])
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[2])), [1.0, 0.0])
-        @test isapprox_arrays(mapping_inv(n, ct, coords(n[3])), [0.0, 1.0])
+        cnodes = get_nodes(mesh, c2n[icell])
+        ctype = cells(mesh)[icell]
+        center = sum(y -> coords(y), cnodes) / length(cnodes)
+        @test isapprox_arrays(mapping(ctype, cnodes, [0.0, 0.0]), coords(cnodes[1]))
+        @test isapprox_arrays(mapping(ctype, cnodes, [1.0, 0.0]), coords(cnodes[2]))
+        @test isapprox_arrays(mapping(ctype, cnodes, [0.0, 1.0]), coords(cnodes[3]))
         @test isapprox(
-            mapping_inv(n, ct, center),
+            mapping(ctype, cnodes, [1 / 3, 1 / 3]),
+            center,
+            rtol = eps(eltype(center)),
+        )
+        @test isapprox(mapping_det_jacobian(cnodes, ctype, 0.0), 1.0, rtol = eps())
+
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[1])), [0.0, 0.0])
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[2])), [1.0, 0.0])
+        @test isapprox_arrays(mapping_inv(cnodes, ctype, coords(cnodes[3])), [0.0, 1.0])
+        @test isapprox(
+            mapping_inv(cnodes, ctype, center),
             [1 / 3, 1 / 3],
             rtol = 10 * eps(eltype(x)),
         )
-        x = coords(n[1])
-        @test isapprox(mapping(n, ct, mapping_inv(n, ct, x)), x, rtol = eps(eltype(x)))
+        x = coords(cnodes[1])
+        @test isapprox(
+            mapping(ctype, cnodes, mapping_inv(cnodes, ctype, x)),
+            x,
+            rtol = eps(eltype(x)),
+        )
     end
 
     function _check_face_parametrization(mesh)
@@ -329,14 +360,14 @@
             ftype = faceTypes[kface]
             fshape = shape(ftype)
             fnodes = get_nodes(mesh, f2n[kface])
-            Fface = mapping(fnodes, ftype)
+            Fface = mapping(ftype, fnodes)
 
             # Neighbor cell i
             i = f2c[kface][1]
             xᵢ = get_nodes(mesh, c2n[i])
             ctᵢ = cellTypes[i]
             shapeᵢ = shape(ctᵢ)
-            Fᵢ = mapping(xᵢ, ctᵢ)
+            Fᵢ = mapping(ctᵢ, xᵢ)
             sideᵢ = cell_side(ctᵢ, c2n[i], f2n[kface])
             fpᵢ = mapping_face(shapeᵢ, sideᵢ) # mapping face-ref -> cell_i-ref
 
@@ -345,7 +376,7 @@
             xⱼ = get_nodes(mesh, c2n[j])
             ctⱼ = cellTypes[j]
             shapeⱼ = shape(ctⱼ)
-            Fⱼ = mapping(xⱼ, ctⱼ)
+            Fⱼ = mapping(ctⱼ, xⱼ)
             sideⱼ = cell_side(ctⱼ, c2n[j], f2n[kface])
             # This part is a bit tricky : we want the face parametrization (face-ref -> cell-ref) on
             # side `j`. For this, we need to know the permutation between the vertices of `kface` and the

--- a/test/mapping/test_ref2phys.jl
+++ b/test/mapping/test_ref2phys.jl
@@ -13,7 +13,7 @@
         ctype = cells(mesh)[1]
         Finv = mapping_inv(cnodes, ctype)
 
-        xc = center(cnodes, ctype)
+        xc = center(ctype, cnodes)
         @test isapprox_arrays(xc, [(xmin + xmax) / 2])
 
         #- Taylor degree 0
@@ -132,7 +132,7 @@
         ctype = cells(mesh)[1]
         Finv = mapping_inv(cnodes, ctype)
 
-        xc = center(cnodes, ctype)
+        xc = center(ctype, cnodes)
         @test all(
             map(
                 (x, y) -> isapprox(x, y; rtol = eps()),

--- a/test/mapping/test_ref2phys.jl
+++ b/test/mapping/test_ref2phys.jl
@@ -10,16 +10,16 @@
         xtest = range(xmin, xmax; length = 5)
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
-        Finv = mapping_inv(cnodes, ct)
+        ctype = cells(mesh)[1]
+        Finv = mapping_inv(cnodes, ctype)
 
-        xc = center(cnodes, ct)
+        xc = center(cnodes, ctype)
         @test isapprox_arrays(xc, [(xmin + xmax) / 2])
 
         #- Taylor degree 0
         fs = FunctionSpace(:Taylor, 0)
         dhl = Bcube.DofHandler(mesh, fs, 1, false)
-        λ = x -> shape_functions(fs, shape(ct), Finv(x))
+        λ = x -> shape_functions(fs, shape(ctype), Finv(x))
         r = rand()
         q = [r]
         u = interpolate(λ, q[dof(dhl, 1)])
@@ -41,7 +41,7 @@
         #- Taylor degree 1
         fs = FunctionSpace(:Taylor, 1)
         dhl = Bcube.DofHandler(mesh, fs, 1, false)
-        λ = x -> shape_functions(fs, shape(ct), Finv(x))
+        λ = x -> shape_functions(fs, shape(ctype), Finv(x))
         coef = rand()
         q = [coef * (xmin + xmax) / 2, (xmax - xmin) * coef] # f(x) = coef*x
         u = interpolate(λ, q[dof(dhl, 1)])
@@ -68,30 +68,30 @@
         xmax = 3.0
         cnodes = [Node([xmin]), Node([xmax])]
         ctype = Bar2_t()
-        @test isapprox_arrays(normal(cnodes, ctype, 1, rand(1)), [-1.0])
-        @test isapprox_arrays(normal(cnodes, ctype, 2, rand(1)), [1.0])
+        @test isapprox_arrays(normal(ctype, cnodes, 1, rand(1)), [-1.0])
+        @test isapprox_arrays(normal(ctype, cnodes, 2, rand(1)), [1.0])
 
         # Bar2_t in 2D
         xmin = [-2.0, -1.0]
         xmax = [3.0, 4.0]
         cnodes = [Node(xmin), Node(xmax)]
         ctype = Bar2_t()
-        @test normal(cnodes, ctype, 1, rand(1)) ≈ √(2) / 2 .* [-1, -1]
-        @test normal(cnodes, ctype, 2, rand(1)) ≈ √(2) / 2 .* [1, 1]
+        @test normal(ctype, cnodes, 1, rand(1)) ≈ √(2) / 2 .* [-1, -1]
+        @test normal(ctype, cnodes, 2, rand(1)) ≈ √(2) / 2 .* [1, 1]
 
         # Bar2_t in 3D
         xmin = [-2.0, -1.0, 5.0]
         xmax = [3.0, 4.0, 0.0]
         cnodes = [Node(xmin), Node(xmax)]
         ctype = Bar2_t()
-        @test normal(cnodes, ctype, 1, rand(1)) ≈ √(3) / 3 * [-1, -1, 1]
-        @test normal(cnodes, ctype, 2, rand(1)) ≈ √(3) / 3 * [1, 1, -1]
+        @test normal(ctype, cnodes, 1, rand(1)) ≈ √(3) / 3 * [-1, -1, 1]
+        @test normal(ctype, cnodes, 2, rand(1)) ≈ √(3) / 3 * [1, 1, -1]
 
         # Bar3_t in 3D (checked graphically, see notebook)
         cnodes = [Node([0.0, 0.0, 1.0]), Node([1.0, 0.0, 3.0]), Node([0.5, 0.5, 2.0])]
         ctype = Bar3_t()
-        @test normal(cnodes, ctype, 1, rand(1)) ≈ 1.0 / 3.0 .* [-1, -2, -2]
-        @test normal(cnodes, ctype, 2, rand(1)) ≈ 1.0 / 3.0 .* [1, -2, 2]
+        @test normal(ctype, cnodes, 1, rand(1)) ≈ 1.0 / 3.0 .* [-1, -2, -2]
+        @test normal(ctype, cnodes, 2, rand(1)) ≈ 1.0 / 3.0 .* [1, -2, 2]
     end
 
     @testset "Triangle" begin
@@ -99,18 +99,18 @@
         # Triangle3_t in 2D
         cnodes = [Node([0.0, 0.0]), Node([1.0, 1.0]), Node([0.0, 2.0])]
         ctype = Tri3_t()
-        @test normal(cnodes, ctype, 1, myrand(1, -1.0, 1.0)) ≈ √(2) / 2 .* [1, -1]
-        @test normal(cnodes, ctype, 2, myrand(1, -1.0, 1.0)) ≈ √(2) / 2 .* [1, 1]
-        @test normal(cnodes, ctype, 3, myrand(1, -1.0, 1.0)) ≈ [-1.0, 0.0]
+        @test normal(ctype, cnodes, 1, myrand(1, -1.0, 1.0)) ≈ √(2) / 2 .* [1, -1]
+        @test normal(ctype, cnodes, 2, myrand(1, -1.0, 1.0)) ≈ √(2) / 2 .* [1, 1]
+        @test normal(ctype, cnodes, 3, myrand(1, -1.0, 1.0)) ≈ [-1.0, 0.0]
 
         # Triangle3_t in 3D (checked graphically, see notebook)
         cnodes = [Node([-0.5, -1.0, -0.3]), Node([0.5, 0.0, 0.0]), Node([-0.5, 1.0, 0.5])]
         ctype = Tri3_t()
-        @test normal(cnodes, ctype, 1, myrand(1, -1.0, 1.0)) ≈
+        @test normal(ctype, cnodes, 1, myrand(1, -1.0, 1.0)) ≈
               [0.7162290778315695, -0.6203055406219843, -0.3197451240319506]
-        @test normal(cnodes, ctype, 2, myrand(1, -1.0, 1.0)) ≈
+        @test normal(ctype, cnodes, 2, myrand(1, -1.0, 1.0)) ≈
               [0.7396002616336388, 0.647150228929434, 0.1849000654084097]
-        @test normal(cnodes, ctype, 3, myrand(1, -1.0, 1.0)) ≈
+        @test normal(ctype, cnodes, 3, myrand(1, -1.0, 1.0)) ≈
               [-0.9957173250742359, -0.034335080174973664, 0.08583770043743415]
     end
 
@@ -129,10 +129,10 @@
         ]
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
-        Finv = mapping_inv(cnodes, ct)
+        ctype = cells(mesh)[1]
+        Finv = mapping_inv(cnodes, ctype)
 
-        xc = center(cnodes, ct)
+        xc = center(cnodes, ctype)
         @test all(
             map(
                 (x, y) -> isapprox(x, y; rtol = eps()),
@@ -144,7 +144,7 @@
         #- Taylor degree 0
         fs = FunctionSpace(:Taylor, 0)
         dhl = Bcube.DofHandler(mesh, fs, 1, false)
-        λ = shape_functions(fs, shape(ct))
+        λ = shape_functions(fs, shape(ctype))
         r = rand()
         q = [r]
         u = interpolate(λ, q[dof(dhl, 1)])
@@ -166,7 +166,7 @@
         #- Taylor degree 1
         fs = FunctionSpace(:Taylor, 1)
         dhl = Bcube.DofHandler(mesh, fs, 1, false)
-        λ = x -> shape_functions(fs, shape(ct), Finv(x))
+        λ = x -> shape_functions(fs, shape(ctype), Finv(x))
         coefx, coefy = rand(2)
         q = [[coefx, coefy] ⋅ xc, Δx * coefx, Δy * coefy] # f(x,y) = coefx*x + coefy*y
         u = interpolate(λ, q[dof(dhl, 1)])
@@ -198,7 +198,7 @@
         )
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
-        ct = cells(mesh)[1]
+        ctype = cells(mesh)[1]
 
         AB = B - A
         BC = C - B
@@ -210,10 +210,10 @@
         nCD = normalize(-[-CD[2], CD[1]])
         nDA = normalize(-[-DA[2], DA[1]])
 
-        @test isapprox_arrays(normal(cnodes, ct, 1, rand(2)), nAB)
-        @test isapprox_arrays(normal(cnodes, ct, 2, rand(2)), nBC)
-        @test isapprox_arrays(normal(cnodes, ct, 3, rand(2)), nCD)
-        @test isapprox_arrays(normal(cnodes, ct, 4, rand(2)), nDA)
+        @test isapprox_arrays(normal(ctype, cnodes, 1, rand(2)), nAB)
+        @test isapprox_arrays(normal(ctype, cnodes, 2, rand(2)), nBC)
+        @test isapprox_arrays(normal(ctype, cnodes, 3, rand(2)), nCD)
+        @test isapprox_arrays(normal(ctype, cnodes, 4, rand(2)), nDA)
 
         # Quad9
         # Normals (checked graphically, see notebook)
@@ -231,13 +231,13 @@
         ctype = Quad9_t()
 
         xq = [0.5773502691896258]
-        @test normal(cnodes, ctype, 1, -xq) ≈ [-0.35921060405354993, -0.9332565252573828]
-        @test normal(cnodes, ctype, 1, xq) ≈ [0.3592106040535497, -0.9332565252573829]
-        @test normal(cnodes, ctype, 2, -xq) ≈ [0.8660254037844385, -0.5000000000000004]
-        @test normal(cnodes, ctype, 2, xq) ≈ [0.8660254037844386, 0.5000000000000003]
-        @test normal(cnodes, ctype, 3, -xq) ≈ [0.3592106040535492, 0.9332565252573829]
-        @test normal(cnodes, ctype, 3, xq) ≈ [-0.3592106040535494, 0.9332565252573829]
-        @test normal(cnodes, ctype, 4, -xq) ≈ [-0.8660254037844388, 0.5]
-        @test normal(cnodes, ctype, 4, xq) ≈ [-0.8660254037844385, -0.5000000000000001]
+        @test normal(ctype, cnodes, 1, -xq) ≈ [-0.35921060405354993, -0.9332565252573828]
+        @test normal(ctype, cnodes, 1, xq) ≈ [0.3592106040535497, -0.9332565252573829]
+        @test normal(ctype, cnodes, 2, -xq) ≈ [0.8660254037844385, -0.5000000000000004]
+        @test normal(ctype, cnodes, 2, xq) ≈ [0.8660254037844386, 0.5000000000000003]
+        @test normal(ctype, cnodes, 3, -xq) ≈ [0.3592106040535492, 0.9332565252573829]
+        @test normal(ctype, cnodes, 3, xq) ≈ [-0.3592106040535494, 0.9332565252573829]
+        @test normal(ctype, cnodes, 4, -xq) ≈ [-0.8660254037844388, 0.5]
+        @test normal(ctype, cnodes, 4, xq) ≈ [-0.8660254037844385, -0.5000000000000001]
     end
 end

--- a/test/mapping/test_ref2phys.jl
+++ b/test/mapping/test_ref2phys.jl
@@ -11,7 +11,7 @@
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
         ctype = cells(mesh)[1]
-        Finv = mapping_inv(cnodes, ctype)
+        Finv = Bcube.mapping_inv(ctype, cnodes)
 
         xc = center(ctype, cnodes)
         @test isapprox_arrays(xc, [(xmin + xmax) / 2])
@@ -130,7 +130,7 @@
         c2n = connectivities_indices(mesh, :c2n)
         cnodes = get_nodes(mesh, c2n[1])
         ctype = cells(mesh)[1]
-        Finv = mapping_inv(cnodes, ctype)
+        Finv = Bcube.mapping_inv(ctype, cnodes)
 
         xc = center(ctype, cnodes)
         @test all(

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -28,7 +28,7 @@
 
         # Scalar test : gradient of scalar `f` in physical coordinates is [1, 2]
         function f1(ξ)
-            x, y = mapping(cnodes, ctype, ξ)
+            x, y = mapping(ctype, cnodes, ξ)
             return x + 2y
         end
         g = ReferenceFunction(f1)
@@ -39,7 +39,7 @@
 
         # Vector test : gradient of vector `f` in physical coordinates is [[1,2],[3,4]]
         function f2(ξ)
-            x, y = mapping(cnodes, ctype, ξ)
+            x, y = mapping(ctype, cnodes, ξ)
             return [x + 2y, 3x + 4y]
         end
         g = ReferenceFunction(f2)
@@ -117,7 +117,7 @@
             c = CellInfo(mesh, 1)
             cnodes = nodes(c)
             ctype = Bcube.celltype(c)
-            F = mapping(cnodes, ctype)
+            F = mapping(ctype, cnodes)
             # tJinv = transpose(R ./ s) # if we want the analytic one...
             tJinv(ξ) = transpose(mapping_jacobian_inv(cnodes, ctype, ξ))
 

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -28,7 +28,7 @@
 
         # Scalar test : gradient of scalar `f` in physical coordinates is [1, 2]
         function f1(ξ)
-            x, y = mapping(ctype, cnodes, ξ)
+            x, y = Bcube.mapping(ctype, cnodes, ξ)
             return x + 2y
         end
         g = ReferenceFunction(f1)
@@ -39,7 +39,7 @@
 
         # Vector test : gradient of vector `f` in physical coordinates is [[1,2],[3,4]]
         function f2(ξ)
-            x, y = mapping(ctype, cnodes, ξ)
+            x, y = Bcube.mapping(ctype, cnodes, ξ)
             return [x + 2y, 3x + 4y]
         end
         g = ReferenceFunction(f2)
@@ -117,9 +117,9 @@
             c = CellInfo(mesh, 1)
             cnodes = nodes(c)
             ctype = Bcube.celltype(c)
-            F = mapping(ctype, cnodes)
+            F = Bcube.mapping(ctype, cnodes)
             # tJinv = transpose(R ./ s) # if we want the analytic one...
-            tJinv(ξ) = transpose(mapping_jacobian_inv(cnodes, ctype, ξ))
+            tJinv(ξ) = transpose(Bcube.mapping_jacobian_inv(cnodes, ctype, ξ))
 
             # Test 1
             u1 = PhysicalFunction(x -> x[1])

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -119,7 +119,7 @@
             ctype = Bcube.celltype(c)
             F = Bcube.mapping(ctype, cnodes)
             # tJinv = transpose(R ./ s) # if we want the analytic one...
-            tJinv(ξ) = transpose(Bcube.mapping_jacobian_inv(cnodes, ctype, ξ))
+            tJinv(ξ) = transpose(Bcube.mapping_jacobian_inv(ctype, cnodes, ξ))
 
             # Test 1
             u1 = PhysicalFunction(x -> x[1])


### PR DESCRIPTION
Every function in Bcube that takes `ctype` and `cnodes` as arguments now uses the same order for them : `(ctype, cnodes)`.

I've checked all the tutorials, and `covo` and `naca` cases.