### PR TITLE
Fix for coplanar_rotation

### DIFF
--- a/src/cellfunction/cellfunction.jl
+++ b/src/cellfunction/cellfunction.jl
@@ -568,7 +568,10 @@ function _coplanar_rotation(
 
     _cos = ν_p ⋅ ν_n
     _sin = cross(ν_p, ν_n) # this is not really a 'sinus', it is (sinus x u)
-    u = normalize(_sin) # WARNING, SHOULD CHECK IF NOT ZERO
+
+    # u = _sin / ||_sin||
+    # So we must ensure that `_sin` is not 0, otherwise we return the null vector
+    u = norm(_sin) > eps() ? normalize(_sin) : _sin
 
     _R = _cos * I + _cross_product_matrix(_sin) + (1 - _cos) * (u ⊗ u)
 

--- a/src/cellfunction/cellfunction.jl
+++ b/src/cellfunction/cellfunction.jl
@@ -572,7 +572,7 @@ function _coplanar_rotation(
     # u = _sin / ||_sin||
     # So we must ensure that `_sin` is not 0, otherwise we return the null vector
     norm_sin = norm(_sin)
-    u = norm_sin > eps(norm_sin) ? normalize(_sin) : _sin
+    u = norm_sin > eps(norm_sin) ? _sin ./ norm_sin : _sin
 
     _R = _cos * I + _cross_product_matrix(_sin) + (1 - _cos) * (u ⊗ u)
 

--- a/src/cellfunction/cellfunction.jl
+++ b/src/cellfunction/cellfunction.jl
@@ -571,7 +571,8 @@ function _coplanar_rotation(
 
     # u = _sin / ||_sin||
     # So we must ensure that `_sin` is not 0, otherwise we return the null vector
-    u = norm(_sin) > eps() ? normalize(_sin) : _sin
+    norm_sin = norm(_sin)
+    u = norm_sin > eps(norm_sin) ? normalize(_sin) : _sin
 
     _R = _cos * I + _cross_product_matrix(_sin) + (1 - _cos) * (u ⊗ u)
 


### PR DESCRIPTION
The case of two faces with colinear normals was not handled correctly, leading to NaNs. It is fixed with this PR.