### PR TITLE
New gallery and project version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bcube"
 uuid = "cf06320b-b7f3-4748-8003-81a6b6979792"
 authors = ["Ghislain Blanchard, Lokman Bennani and Maxime Bouyges"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 FEMQuad = "be8e8821-3f6f-54c2-987c-d2773c3a52cb"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Any contribution(s) and/or remark(s) are welcome! Don't hesitate to open an issu
 ## Gallery
 | [Helmholtz equation](https://bcube-project.github.io/BcubeTutorials.jl/dev/tutorial/helmholtz) | [Phase field solidification](https://bcube-project.github.io/BcubeTutorials.jl/dev/tutorial/phase_field_supercooled) | [Linear transport equation](https://bcube-project.github.io/BcubeTutorials.jl/dev/tutorial/linear_transport) |
 |-|-|-|
-| ![](https://bcube-project.github.io/BcubeTutorials.jl/dev/assets/helmholtz_x21_y21_vp6.png) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/phase-field-supercooled-rectangle.gif) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/linear_transport.gif) |
+| ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/helmholtz_x21_y21_vp6.png?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/phase-field-supercooled-rectangle.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/linear_transport.gif?raw=true) |
+| [Heat equation on a sphere](https://bcube-project.github.io/BcubeTutorials.jl/stable/example/heat_equation_sphere) | [Transport equation on hypersurfaces](https://bcube-project.github.io/BcubeTutorials.jl/stable/example/transport_hypersurface) | [Linear thermo-elasticity](https://bcube-project.github.io/BcubeTutorials.jl/stable/example/linear_thermoelasticity) |
+| ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/heat_equation_sphere.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/transport-torus-mesh2-degree1.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/thermo_elasticity.gif?raw=true) |
 
 ## Authors
 Ghislain Blanchard, Lokman Bennani and Maxime Bouyges

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,9 +36,11 @@ Numerous FEM-DG Julia packages are available, here is a non-exhaustive list;
 Any contribution(s) and/or remark(s) are welcome! Don't hesitate to open an issue to ask a question or signal a bug. PRs improving the code (new features, new elements, fixing bugs, ...) will be greatly appreciated.
 
 ## Gallery
-| [Helmholtz equation](https://bcube-project.github.io/BcubeTutorials.jl/dev/tutorial/helmholtz) | [Phase field solidification](https://bcube-project.github.io/BcubeTutorials.jl/dev/tutorial/phase_field_supercooled) | [Linear transport equation](https://bcube-project.github.io/BcubeTutorials.jl/dev/tutorial/linear_transport) |
+| [Helmholtz equation](https://bcube-project.github.io/BcubeTutorials.jl/stable/tutorial/helmholtz) | [Phase field solidification](https://bcube-project.github.io/BcubeTutorials.jl/stable/tutorial/phase_field_supercooled) | [Linear transport equation](https://bcube-project.github.io/BcubeTutorials.jl/stable/tutorial/linear_transport) |
 | :----------------: | :------------------------: | :-----------------------: |
-| ![](https://bcube-project.github.io/BcubeTutorials.jl/dev/assets/helmholtz_x21_y21_vp6.png) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/phase-field-supercooled-rectangle.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/linear_transport.gif?raw=true) |
+| ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/helmholtz_x21_y21_vp6.png?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/phase-field-supercooled-rectangle.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/linear_transport.gif?raw=true) |
+| [Heat equation on a sphere](https://bcube-project.github.io/BcubeTutorials.jl/stable/example/heat_equation_sphere) | [Transport equation on hypersurfaces](https://bcube-project.github.io/BcubeTutorials.jl/stable/example/transport_hypersurface) | [Linear thermo-elasticity](https://bcube-project.github.io/BcubeTutorials.jl/stable/example/linear_thermoelasticity) |
+| ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/heat_equation_sphere.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/transport-torus-mesh2-degree1.gif?raw=true) | ![](https://github.com/bcube-project/BcubeTutorials.jl/blob/main/docs/src/assets/thermo_elasticity.gif?raw=true) |
 
 
 ## Authors


### PR DESCRIPTION
I propose this new gallery. Check out https://github.com/bcube-project/Bcube.jl/tree/new_gallery (page bottom) and https://bcube-project.github.io/Bcube.jl/previews/PR110 (page bottom)

Once merged, I will tag a new version to obtain our first DOI from Zenodo.