### PR TITLE
Use allocate_dofs in assemble_linear

### DIFF
--- a/src/assembler/assembler.jl
+++ b/src/assembler/assembler.jl
@@ -191,7 +191,7 @@ function assemble_linear(
     V::Union{TestFESpace, AbstractMultiTestFESpace};
     T = Float64,
 )
-    b = zeros(T, get_ndofs(V))
+    b = allocate_dofs(V, T)
     assemble_linear!(b, l, V)
     return b
 end


### PR DESCRIPTION
This tiny modif is usefull for BcubeParallel since `allocate_dofs` is specialized to return an appropriate `HauntedVector`