### PR TITLE
4D tensors algebra

### DIFF
--- a/src/algebra/algebra.jl
+++ b/src/algebra/algebra.jl
@@ -2,6 +2,8 @@ otimes(x::AbstractVector, y::AbstractVector) = x * y'
 otimes(x::AbstractVector) = otimes(x, x)
 
 """
+    otimes(A,B)
+
 Tensors product between second order tensors
 
 # Implementation
@@ -88,6 +90,8 @@ function dcontract(A::AbstractArray{T1, 3}, B::AbstractArray{T2, 3}) where {T1, 
 end
 
 """
+    dcontract(A,B)
+
 Tensors double contraction between fourth order tensor and second order tensor
 
 # Implementation

--- a/src/algebra/algebra.jl
+++ b/src/algebra/algebra.jl
@@ -9,15 +9,11 @@ A[i,j] ⊗ B[k,l] = C[i,j,k,l]
 such as
 C[i,j,k,l] = A[i,j] * B[k,l]
 """
-function otimes(A::AbstractArray{T1, 2}, B::AbstractArray{T2, 2}) where {T1, T2}
+function otimes(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}) where {T1, T2}
     sA = size(A)
     sB = size(B)
-    C = zeros(sA[1], sA[2], sB[1], sB[2])
-    for k in 1:sB[1]
-        for l in 1:sB[2]
-            C[:, :, k, l] = A .* B[k, l]
-        end
-    end
+    C = zeros(promote_type(T1, T2), sA..., sB...)
+    C = [A[i, j] * B[k, l] for i in 1:sA[1], j in 1:sA[2], k in 1:sB[1], l in 1:sB[2]]
     return C
 end
 
@@ -98,11 +94,7 @@ C[i,j] = A[i,j,k,l] * B[k,l] (Einstein sum)
 function dcontract(A::AbstractArray{T1, 4}, B::AbstractArray{T2, 2}) where {T1, T2}
     sA = size(A)
     C = zeros(promote_type(eltype(A), eltype(B)), sA[1], sA[2])
-    for i in 1:sA[1]
-        for j in 1:sA[2]
-            C[i, j] = sum(A[i, j, :, :] .* B)
-        end
-    end
+    C = [sum(A[i, j, :, :] .* B) for i in 1:sA[1], j in 1:sA[2]]
     return C
 end
 

--- a/src/algebra/algebra.jl
+++ b/src/algebra/algebra.jl
@@ -26,7 +26,9 @@ function otimes(
     A::SMatrix{I1, I2, T1, L1},
     B::SMatrix{I3, I4, T2, L2},
 ) where {I1, I2, I3, I4, T1, T2, L1, L2}
-    return SArray{Tuple{I1,I2,I3,I4}}([A[i, j] * B[k, l] for i in 1:I1, j in 1:I2, k in 1:I3, l in 1:I4])
+    return SArray{Tuple{I1, I2, I3, I4}}([
+        A[i, j] * B[k, l] for i in 1:I1, j in 1:I2, k in 1:I3, l in 1:I4
+    ])
 end
 
 const ⊗ = otimes

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -283,14 +283,17 @@
 
     @testset "Tensors" begin
         # otimes
-            # 1D ⊗ 1D = 2D
+        # 1D ⊗ 1D = 2D
         V = rand(rand(2:5))
         @test V ⊗ V == [V[i] * V[j] for i in eachindex(V), j in eachindex(V)]
 
-            # 2D ⊗ 2D = 4D
+        # 2D ⊗ 2D = 4D
         A = rand(rand(2:5), rand(2:5))
         B = rand(rand(2:5), rand(2:5))
-        @test A ⊗ B == [A[i, j] * B[k, l] for i in axes(A, 1), j in axes(A, 2), k in axes(B, 1), l in axes(B, 2)]
+        @test A ⊗ B == [
+            A[i, j] * B[k, l] for i in axes(A, 1), j in axes(A, 2), k in axes(B, 1),
+            l in axes(B, 2)
+        ]
         A_SA = SMatrix{size(A)...}(A)
         B_SA = SMatrix{size(B)...}(B)
         @test A_SA ⊗ B_SA == A ⊗ B
@@ -299,52 +302,66 @@
         # dcontract
         m, n = rand(2:5, 2)
 
-            # 2D ⊡ 2D = 0D
+        # 2D ⊡ 2D = 0D
         A = rand(m, m)
-        Id = [i == j for i in 1:m, j = 1:m]
+        Id = [i == j for i in 1:m, j in 1:m]
         @test A ⊡ Id == tr(A)
 
         A = rand(m, n)
         B = rand(m, n)
-        @test A ⊡ B == sum(A[j,k] * B[j,k] for j in 1:m, k in 1:n)
+        @test A ⊡ B == sum(A[j, k] * B[j, k] for j in 1:m, k in 1:n)
 
-            # 3D ⊡ 2D = 1D
+        # 3D ⊡ 2D = 1D
         A = rand(rand(2:5), m, n)
         B = rand(m, n)
-        @test A ⊡ B == [sum(A[i,j,k] * B[j,k] for j in 1:m, k in 1:n) for i in axes(A,1)]
+        @test A ⊡ B ==
+              [sum(A[i, j, k] * B[j, k] for j in 1:m, k in 1:n) for i in axes(A, 1)]
         A_SA = SArray{Tuple{size(A)...}}(A)
         B_SA = SMatrix{size(B)...}(B)
         @test A_SA ⊡ B_SA == A ⊡ B
         @test typeof(A_SA ⊡ B_SA) <: SVector
 
-            # 3D ⊡ 3D = 2D
+        # 3D ⊡ 3D = 2D
         A = rand(rand(2:5), m, n)
         B = rand(rand(2:5), m, n)
-        @test A ⊡ B == [sum(A[i,j,k] * B[l,j,k] for j in 1:m, k in 1:n) for i in axes(A,1), l in axes(B,1)]
+        @test A ⊡ B == [
+            sum(A[i, j, k] * B[l, j, k] for j in 1:m, k in 1:n) for i in axes(A, 1),
+            l in axes(B, 1)
+        ]
         A_SA = SArray{Tuple{size(A)...}}(A)
         B_SA = SArray{Tuple{size(B)...}}(B)
         @test A_SA ⊡ B_SA == A ⊡ B
         @test typeof(A_SA ⊡ B_SA) <: SMatrix
 
-            # 4D ⊡ 2D = 2D
+        # 4D ⊡ 2D = 2D
 
         # 4D Identity tensor : Id4D ⊡ A = A
-        Id4D = @SArray [i == k && j == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
+        Id4D = @SArray [
+            i == k && j == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2
+        ]
         # 4D Symmetrical identity tensor : Id4DSym ⊡ A = A, with A symmetrical
-        Id4DSym = @SArray [i == j == k == l ? 1.0 : i != j && k != l ? 0.5 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
+        Id4DSym = @SArray [
+            i == j == k == l ? 1.0 : i != j && k != l ? 0.5 : 0.0 for i in 1:2,
+            j in 1:2, k in 1:2, l in 1:2
+        ]
         # 4D Trace tensor : tr4D ⊡ A = tr(A) * Id2D
-        tr4D = @SArray [i == j && k == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
+        tr4D = @SArray [
+            i == j && k == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2
+        ]
 
         A = rand(2, 2)
         Id = [i == j for i in 1:2, j in 1:2]
         @test tr4D ⊡ A == tr(A) * Id
         @test Id4D ⊡ A == A
         @test Id4DSym ⊡ A != A
-        @test Id4DSym ⊡ (A*A') == A*A'
+        @test Id4DSym ⊡ (A * A') == A * A'
 
         A = rand(rand(2:5), rand(2:5), m, n)
         B = rand(m, n)
-        @test A ⊡ B == [sum(A[i,j,k,l] * B[k,l] for k in 1:m, l in 1:n) for i in axes(A,1), j in axes(A,2)]
+        @test A ⊡ B == [
+            sum(A[i, j, k, l] * B[k, l] for k in 1:m, l in 1:n) for i in axes(A, 1),
+            j in axes(A, 2)
+        ]
         A_SA = SArray{Tuple{size(A)...}}(A)
         B_SA = SMatrix{size(B)...}(B)
         @test A_SA ⊡ B_SA == A ⊡ B

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -281,6 +281,76 @@
         @test dcontract(a, f) == a
     end
 
+    @testset "Tensors" begin
+        # otimes
+            # 1D ⊗ 1D = 2D
+        V = rand(rand(2:5))
+        @test V ⊗ V == [V[i] * V[j] for i in eachindex(V), j in eachindex(V)]
+
+            # 2D ⊗ 2D = 4D
+        A = rand(rand(2:5), rand(2:5))
+        B = rand(rand(2:5), rand(2:5))
+        @test A ⊗ B == [A[i, j] * B[k, l] for i in axes(A, 1), j in axes(A, 2), k in axes(B, 1), l in axes(B, 2)]
+        A_SA = SMatrix{size(A)...}(A)
+        B_SA = SMatrix{size(B)...}(B)
+        @test A_SA ⊗ B_SA == A ⊗ B
+        @test typeof(A_SA ⊗ B_SA) <: SArray
+
+        # dcontract
+        m, n = rand(2:5, 2)
+
+            # 2D ⊡ 2D = 0D
+        A = rand(m, m)
+        Id = [i == j for i in 1:m, j = 1:m]
+        @test A ⊡ Id == tr(A)
+
+        A = rand(m, n)
+        B = rand(m, n)
+        @test A ⊡ B == sum(A[j,k] * B[j,k] for j in 1:m, k in 1:n)
+
+            # 3D ⊡ 2D = 1D
+        A = rand(rand(2:5), m, n)
+        B = rand(m, n)
+        @test A ⊡ B == [sum(A[i,j,k] * B[j,k] for j in 1:m, k in 1:n) for i in axes(A,1)]
+        A_SA = SArray{Tuple{size(A)...}}(A)
+        B_SA = SMatrix{size(B)...}(B)
+        @test A_SA ⊡ B_SA == A ⊡ B
+        @test typeof(A_SA ⊡ B_SA) <: SVector
+
+            # 3D ⊡ 3D = 2D
+        A = rand(rand(2:5), m, n)
+        B = rand(rand(2:5), m, n)
+        @test A ⊡ B == [sum(A[i,j,k] * B[l,j,k] for j in 1:m, k in 1:n) for i in axes(A,1), l in axes(B,1)]
+        A_SA = SArray{Tuple{size(A)...}}(A)
+        B_SA = SArray{Tuple{size(B)...}}(B)
+        @test A_SA ⊡ B_SA == A ⊡ B
+        @test typeof(A_SA ⊡ B_SA) <: SMatrix
+
+            # 4D ⊡ 2D = 2D
+
+        # 4D Identity tensor : Id4D ⊡ A = A
+        Id4D = @SArray [i == k && j == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
+        # 4D Symmetrical identity tensor : Id4DSym ⊡ A = A, with A symmetrical
+        Id4DSym = @SArray [i == j == k == l ? 1.0 : i != j && k != l ? 0.5 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
+        # 4D Trace tensor : tr4D ⊡ A = tr(A) * Id2D
+        tr4D = @SArray [i == j && k == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
+
+        A = rand(2, 2)
+        Id = [i == j for i in 1:m, j in 1:m]
+        @test tr4D ⊡ A == tr(A) * Id
+        @test Id4D ⊡ A == A
+        @test Id4DSym ⊡ A != A
+        @test Id4DSym ⊡ (A*A') == A*A'
+
+        A = rand(rand(2:5), rand(2:5), m, n)
+        B = rand(m, n)
+        @test A ⊡ B == [sum(A[i,j,k,l] * B[k,l] for k in 1:m, l in 1:n) for i in axes(A,1), j in axes(A,2)]
+        A_SA = SArray{Tuple{size(A)...}}(A)
+        B_SA = SMatrix{size(B)...}(B)
+        @test A_SA ⊡ B_SA == A ⊡ B
+        @test typeof(A_SA ⊡ B_SA) <: SMatrix
+    end
+
     @testset "UniformScaling" begin
         mesh = one_cell_mesh(:quad)
         U = TrialFESpace(FunctionSpace(:Lagrange, 1), mesh; size = 2)

--- a/test/operator/test_algebra.jl
+++ b/test/operator/test_algebra.jl
@@ -336,7 +336,7 @@
         tr4D = @SArray [i == j && k == l ? 1.0 : 0.0 for i in 1:2, j in 1:2, k in 1:2, l in 1:2]
 
         A = rand(2, 2)
-        Id = [i == j for i in 1:m, j in 1:m]
+        Id = [i == j for i in 1:2, j in 1:2]
         @test tr4D ⊡ A == tr(A) * Id
         @test Id4D ⊡ A == A
         @test Id4DSym ⊡ A != A


### PR DESCRIPTION
Add 2D tensor product and 4D-2D double contraction operations with tests

- Add tensor product for two second-order tensors (2D ⊗ 2D → 4D) with StaticArrays support.
- Add 4D-2D double contraction operation for a fourth-order tensor and a second-order tensor (4D ⊡ 2D → 2D) with StaticArrays support.
- Include unit tests to validate the correctness of tensor product and double contraction implementations.
