### PR TITLE
Fix assertion in projection_l2

### DIFF
--- a/src/feoperator/projection_newapi.jl
+++ b/src/feoperator/projection_newapi.jl
@@ -48,7 +48,7 @@ function projection_l2!(u::AbstractSingleFieldFEFunction, f, dΩ::Measure; mass 
         a(u, v) = ∫(u ⋅ v)dΩ
         A = assemble_bilinear(a, U, V)
     else
-        @assert mass isa AbstractMatrix "`mass` must be a matrix. If you use `projection_l2!` on a `MultiFieldFEFunction`, make sure to provide a Tuple of mass matrices and not the whole system matrix."
+        @assert mass isa Union{AbstractMatrix, Factorization} "`mass` must be a matrix. If you use `projection_l2!` on a `MultiFieldFEFunction`, make sure to provide a Tuple of mass matrices and not the whole system matrix."
         A = mass
     end
     l(v) = ∫(f ⋅ v)dΩ


### PR DESCRIPTION
A few weeks ago, I added an `assert` in `projection_l2!` to help troubleshooting when a user tries to use this function with the mass matrix of a whole `MultiFESpace` instead of passing the tuple of mass matrices.

However the current assertion is too restrictive and forbids factorized mass matrix, which is a shame for repetitive calls!