### PR TITLE
`domain_to_mesh` for AbstractFaceDomain

### DIFF
--- a/src/mesh/domain.jl
+++ b/src/mesh/domain.jl
@@ -585,17 +585,18 @@ function identify_cells(mesh::Mesh, f::Function, all_nodes = true)
 end
 
 """
-    domain_to_mesh(::AbstractDomain)
+    domain_to_mesh(::AbstractDomain; kwargs...)
 
 Convert an `AbstractDomain` to a `Mesh`.
 
-The new boundary faces, if any, obtained by selecting a portion of the original mesh are
-tagged with the value of the argument `clipped_bnd_name`.
-"""
-domain_to_mesh(::AbstractDomain, clipped_bnd_name = "CLIPPED_BND") =
-    error("not implemented yet")
+For an `AbstractCellDomain`, The new boundary faces, if any, obtained by selecting a portion of the original mesh are
+tagged with the value of the keyword argument `clipped_bnd_name`.
 
-function domain_to_mesh(domain::CellDomain, clipped_bnd_name = "CLIPPED_BND")
+For a `BoundaryFaceDomain`, the new boundary faces (with respect to this domain) are tagged.
+"""
+domain_to_mesh(::AbstractDomain; kwargs...) = error("not implemented yet")
+
+function domain_to_mesh(domain::CellDomain; clipped_bnd_name = "CLIPPED_BND")
     # Note : `_o2n` means "old to new" while `_n2o` means "new to old"
 
     # Alias
@@ -661,4 +662,79 @@ function domain_to_mesh(domain::CellDomain, clipped_bnd_name = "CLIPPED_BND")
         bc_names = bnd_names,
         bc_nodes = bnd_nodes,
     )
+end
+
+function domain_to_mesh(domain::AbstractFaceDomain)
+    # Unpack the domain
+    mesh = get_mesh(domain)
+    kfaces = indices(domain)
+
+    @assert topodim(mesh) >= 2
+
+    _f2n = connectivities_indices(mesh, :f2n)
+    f2n = [_f2n[kface] for kface in kfaces]
+
+    # Within the loop below, we:
+    # - identify the subset of nodes needed for the new mesh
+    # - build the node loc -> glo mapping simultaneously
+    # - construct the "c2n" with the new (local) numbering
+    tag = zeros(Bool, nnodes(mesh))
+    offset = 1
+    loc2glo = zeros(Int, nnodes(mesh)) # overdimensionned
+    glo2loc = zero(loc2glo)
+    for inodes in f2n
+        for inode in inodes
+            if !tag[inode]
+                tag[inode] = true
+                loc2glo[offset] = inode
+                offset += 1
+            end
+        end
+    end
+    loc2glo = loc2glo[1:(offset - 1)]
+    glo2loc[loc2glo] .= collect(1:length(loc2glo))
+
+    # New "c2n" with updated nodes
+    c2n = Connectivity(length.(f2n), glo2loc[reduce(vcat, f2n)])
+
+    # "Cell" types
+    ctypes = faces(mesh)[kfaces]
+
+    # Nodes
+    nodes = get_nodes(mesh)[loc2glo]
+
+    # Metadata
+    metadata = ParentMeshMetaData(loc2glo, kfaces)
+
+    # Finished if not a BoundaryFaceDomain
+    (domain isa BoundaryFaceDomain) || return return Mesh(nodes, ctypes, c2n; metadata)
+
+    # Empty bc 
+    bc_names = Dict{Int, String}()
+    bc_nodes = Dict{Int, Vector{Int}}()
+
+    for (tag, bnd_name) in boundary_names(mesh)
+        # If the boundary is already part of the domain, we skip it
+        (bnd_name ∈ domain.labels) && continue
+
+        _bc_nodes = Int[]
+        sizehint!(_bc_nodes, length(loc2glo))
+
+        for iface in boundary_faces(mesh, tag)
+            for inode in _f2n[iface]
+                g2l = glo2loc[inode]
+                # If the local number of this node is >0, it means that it belongs
+                # to the mesh we want to extract
+                (g2l > 0) && push!(_bc_nodes, g2l)
+            end
+        end
+
+        if length(_bc_nodes) > 0
+            bc_names[tag] = bnd_name
+            bc_nodes[tag] = _bc_nodes
+        end
+    end
+
+    # New mesh
+    return Mesh(nodes, ctypes, c2n; bc_names, bc_nodes, metadata)
 end

--- a/src/mesh/mesh.jl
+++ b/src/mesh/mesh.jl
@@ -72,7 +72,9 @@ function Base.show(io::IO, c::MeshConnectivity)
 end
 
 """
-Mesh metadata intended to store informations about "zones" (or "domains") originally
+Mesh metadata that can serve several/any purposes.
+
+Initially, it's intended to store informations about "zones" (or "domains") originally
 stored in the mesh file.
 
 # Devs notes
@@ -104,6 +106,17 @@ end
 struct DefaultMeshMetaData <: AbstractMeshMetaData end
 get_zone_names(::DefaultMeshMetaData, ::AbstractMesh) = ("Zone",)
 get_zone_element_indices(::DefaultMeshMetaData, mesh::AbstractMesh, name) = 1:ncells(mesh)
+
+struct ParentMeshMetaData{A, B} <: AbstractMeshMetaData
+    # local mesh node number -> parent mesh node number
+    node_l2g::A
+    # local mesh elt (face, cell) number -> parent mesh elt (face, cell) number
+    # Rq: it can be a local-cell-number -> parent-face-number
+    elt_l2g::B
+end
+
+@inline get_node_loc_to_glob(metadata::ParentMeshMetaData) = metadata.node_l2g
+@inline get_elt_loc_to_glob(metadata::ParentMeshMetaData) = metadata.elt_l2g
 
 """
 `bc_names` : <boundary tag> => <boundary names>

--- a/test/mesh/test_domain.jl
+++ b/test/mesh/test_domain.jl
@@ -30,6 +30,7 @@
     @testset "domain-to-mesh" begin
         mesh = rectangle_mesh(3, 4)
 
+        # CellDomain
         f(x) = norm(x) > 0.5
         ind = Bcube.identify_cells(mesh, f)
         Ω = CellDomain(mesh, ind)
@@ -45,5 +46,16 @@
         @test Bcube.boundary_faces(new_mesh, "xmax") == [2, 9]
         @test "ymin" ∉ values(boundary_names(new_mesh))
         @test Bcube.boundary_faces(new_mesh, "ymax") == [7, 10]
+
+        # BoundaryFaceDomain
+        Γ = BoundaryFaceDomain(mesh, ("xmin", "ymax"))
+        new_mesh = Bcube.domain_to_mesh(Γ)
+
+        @test nnodes(new_mesh) == 6
+        @test ncells(new_mesh) == 5
+        @test Bcube.inner_faces(new_mesh) == [1, 3, 4, 5]
+        @test Bcube.outer_faces(new_mesh) == [2, 6]
+        @test Bcube.boundary_faces(new_mesh, "xmax") == [6]
+        @test Bcube.boundary_faces(new_mesh, "ymin") == [2]
     end
 end


### PR DESCRIPTION
Whatever the path we'll choose for the volume-surface coupling, we'll need this function at some point. Note that the `ParentMeshMetaData` isn't strictly necessary, but might be usefull.