### PR TITLE
Fix: compute for MultiIntegration (#101)

### DIFF
--- a/src/assembler/assembler.jl
+++ b/src/assembler/assembler.jl
@@ -777,6 +777,45 @@ end
 _domain_to_mesh_nelts(domain::AbstractCellDomain) = ncells(get_mesh(domain))
 _domain_to_mesh_nelts(domain::AbstractFaceDomain) = nfaces(get_mesh(domain))
 
+
+"""
+    compute(multi::MultiIntegration)
+
+Evaluates a sum of integrals stored in a `MultiIntegration` object.
+
+Each sub-integral is of the form `∫(f)dΩ`, computed over a specific domain
+with a given quadrature. The result of `compute(multi)` is the sum of the
+results of `compute` applied to each individual `Integration`.
+
+Returns a `SparseVector` whose indices correspond to the mesh entities
+(cells, faces, etc.) of the integration domains. The values represent the
+total integral contribution over those entities.
+
+# Example
+```julia
+mesh = line_mesh(4)
+Ω    = CellDomain(mesh)
+dΩ   = Measure(Ω, 2)
+f    = PhysicalFunction(x -> 1.0)
+int1 = ∫(f)dΩ
+int2 = 2.0 * int1
+multi = int1 + int2
+res = compute(multi)  # should be equal to 3 * compute(int1)
+"""
+
+function compute(multi::MultiIntegration{N}) where {N}
+    ∑ = compute(multi[Val(1)]) 
+    N == 1 && return ∑
+    for i in 2:N
+        tmp = compute(multi[Val(i)])
+        @assert length(tmp) == length(∑) "Measures don't fit."
+        ∑ .+= tmp
+    end
+    return ∑
+end
+
+
+
 """
     AbstractFaceSidePair{A} <: AbstractLazyWrap{A}
 

--- a/test/issues/issue_101.jl
+++ b/test/issues/issue_101.jl
@@ -1,0 +1,18 @@
+@testset "issue #101" begin
+    function run()
+        mesh = line_mesh(4)
+        Ω    = CellDomain(mesh)
+        dΩ   = Measure(Ω, 2)
+
+        f  = PhysicalFunction(x -> 1.0)
+        int1 = ∫(f)dΩ
+        int2 = 2.0 * int1
+
+        res  = compute(int1 + int2)
+        vols = compute(int1)
+
+        @test maximum(abs.(res .- 3 .* vols)) < 1e-12
+    end
+
+    run()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,5 +165,6 @@ tempdir = mktempdir()
     @testset "Issues" begin
         custom_include("./issues/issue_112.jl")
         custom_include("./issues/issue_130.jl")
+        custom_include("./issues/issue_101.jl")
     end
 end


### PR DESCRIPTION
Add computation of a MultiIntegration object, by implementing compute(::MultiIntegration).

Recursively calls "compute(::Integration)" and accumulates the results in a SparseVector.

A unit test has been added in "test/issues/issue_101.jl" to validate the fix.